### PR TITLE
Depending on HMCTS pdf generator jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,9 +135,6 @@ repositories {
   maven {
     url  "https://dl.bintray.com/hmcts/hmcts-maven"
   }
-  maven {
-    url "https://dl.bintray.com/mcausland/generic"
-  }
   jcenter()
 }
 
@@ -178,7 +175,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.4.2'
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.3.0'
-  compile group: 'com.hmcts', name: 'pdf-generator', version: '1.0.2'
+  compile group: 'uk.gov.hmcts.reform', name: 'pdf-generator', version: '1.0.2'
 
 
   compile group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback


### PR DESCRIPTION
I got the pdf jar deployed to the hmcts bintray so we can drop the dependency on my custom bintray repo.