### PR TITLE
Introduce RootController

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/RootController.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.sendletter.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+/**
+ * Default endpoints per application.
+ */
+@RestController
+public class RootController {
+
+    /**
+     * Root GET endpoint.
+     *
+     * <p>Azure application service has a hidden feature of making requests to root endpoint when
+     * "Always On" is turned on.
+     * This is the endpoint to deal with that and therefore silence the unnecessary 404s as a response code.
+     *
+     * @return Welcome message from the service.
+     */
+    @GetMapping
+    public ResponseEntity<String> welcome() {
+        return ok("Welcome to Send Letter Service");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/GetWelcomeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/GetWelcomeControllerTest.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.sendletter.controllers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.sendletter.services.AuthService;
+import uk.gov.hmcts.reform.sendletter.services.LetterService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest
+public class GetWelcomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LetterService service; // NOPMD we only need context to load
+
+    @MockBean
+    private AuthService authService; // NOPMD we only need context to load
+
+    @Test
+    public void should_welcome_upon_root_request_with_200_response_code() throws Exception {
+        mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Welcome to Send Letter Service"));
+    }
+}


### PR DESCRIPTION
Azure App Service has "Always On" feature which silently hits "/" root endpoint. Adding welcome message to fix 404 reporting in AppInsights

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
