### PR TITLE
Add transactional attribute to SendLetter tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.data.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.data.model.DbLetter;
@@ -38,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@Transactional
 public class GetLetterStatusTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@Transactional
 public class SendLetterTest {
 
     @Autowired


### PR DESCRIPTION
### Change description ###

Fix the integration tests by ensuring records are not committed to the test database but rolled back, so that every test starts from a clean state.