### PR TITLE
Letter cleanup

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.data.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.data.model.DbLetter;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.out.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.util.MessageIdProvider;
 
@@ -61,7 +61,7 @@ public class GetLetterStatusTest {
 
         // and
         UUID letterId = UUID.randomUUID();
-        Letter letter = new Letter(Collections.emptyList(), "some-type", Collections.emptyMap());
+        LetterRequest letter = new LetterRequest(Collections.emptyList(), "some-type", Collections.emptyMap());
         DbLetter dbLetter = new DbLetter(letterId, "some-service", letter);
         ZonedDateTime createdAt = ZonedDateTime.now(ZoneOffset.UTC);
         String messageId = MessageIdProvider.randomMessageId();

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.out.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.model.out.SendLetterResponse;
 import uk.gov.hmcts.reform.sendletter.services.AuthService;
@@ -55,7 +55,7 @@ public class SendLetterController {
     public ResponseEntity<SendLetterResponse> sendLetter(
         @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader,
         @ApiParam(value = "Letter consisting of documents and type", required = true)
-        @Valid @RequestBody Letter letter
+        @Valid @RequestBody LetterRequest letter
     ) throws JsonProcessingException {
 
         String serviceName = authService.authenticate(serviceAuthHeader);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/data/model/DbLetter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/data/model/DbLetter.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.data.model;
 
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +29,7 @@ public class DbLetter {
         this.additionalData = additionalData;
     }
 
-    public DbLetter(UUID id, String service, Letter letter) {
+    public DbLetter(UUID id, String service, LetterRequest letter) {
         this(id, letter.documents, letter.type, service, letter.additionalData);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/model/in/LetterRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/model/in/LetterRequest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
-public class Letter implements Serializable {
+public class LetterRequest implements Serializable {
 
     private static final long serialVersionUID = -7737087336283080072L;
 
@@ -26,7 +26,7 @@ public class Letter implements Serializable {
     @JsonProperty("additional_data")
     public final Map<String, Object> additionalData;
 
-    public Letter(
+    public LetterRequest(
         @JsonProperty("documents") List<Document> documents,
         @JsonProperty("type") String type,
         @JsonProperty("additional_data") Map<String, Object> additionalData

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterChecksumGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterChecksumGenerator.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.services;
 
 import org.springframework.util.DigestUtils;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 
 import static org.springframework.util.SerializationUtils.serialize;
 
@@ -10,7 +10,7 @@ public final class LetterChecksumGenerator {
     private LetterChecksumGenerator() {
     }
 
-    public static String generateChecksum(Letter letter) {
+    public static String generateChecksum(LetterRequest letter) {
         return DigestUtils.md5DigestAsHex(serialize(letter));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.out.LetterStatus;
 import uk.gov.hmcts.reform.slc.services.steps.getpdf.PdfCreator;
 import uk.gov.hmcts.reform.slc.services.steps.getpdf.duplex.DuplexPreparator;
@@ -30,7 +30,7 @@ public class LetterService {
         this.letterRepository = letterRepository;
     }
 
-    public UUID send(Letter letter, String serviceName) {
+    public UUID send(LetterRequest letter, String serviceName) {
         Asserts.notEmpty(serviceName, "serviceName");
 
         final String messageId = generateChecksum(letter);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -35,12 +35,8 @@ public class LetterService {
         Asserts.notEmpty(serviceName, "serviceName");
 
         final String messageId = generateChecksum(letter);
-        final UUID id = UUID.randomUUID();
 
-        log.info("Generated message: id = {} for letter with print queue id = {} and letter id = {} ",
-            messageId,
-            letter.type,
-            id);
+        log.info("Generated message: id = {} for letter with print queue id = {}", messageId, letter.type);
 
         byte[] pdf = pdfCreator.create(letter);
         Letter dbLetter = new Letter(messageId, serviceName, null, letter.type, pdf);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -4,6 +4,7 @@ import org.apache.http.util.Asserts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
@@ -42,8 +43,7 @@ public class LetterService {
             id);
 
         byte[] pdf = pdfCreator.create(letter);
-        uk.gov.hmcts.reform.sendletter.entity.Letter dbLetter = new uk.gov.hmcts.reform.sendletter.entity.Letter(
-            messageId, serviceName, null, letter.type, pdf);
+        Letter dbLetter = new Letter(messageId, serviceName, null, letter.type, pdf);
 
         letterRepository.save(dbLetter);
         return dbLetter.getId();
@@ -55,10 +55,9 @@ public class LetterService {
     }
 
     public LetterStatus getStatus(UUID id, String serviceName) {
-        uk.gov.hmcts.reform.sendletter.entity.Letter letter =
-            letterRepository
-                .findByIdAndService(id, serviceName)
-                .orElseThrow(() -> new LetterNotFoundException(id));
+        Letter letter = letterRepository
+            .findByIdAndService(id, serviceName)
+            .orElseThrow(() -> new LetterNotFoundException(id));
 
         return new LetterStatus(
             id,

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
@@ -4,7 +4,7 @@ import org.apache.http.util.Asserts;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.slc.services.steps.getpdf.duplex.DuplexPreparator;
 
 import java.util.List;
@@ -21,7 +21,7 @@ public class PdfCreator {
         this.duplexPreparator = duplexPreparator;
     }
 
-    public byte[] create(Letter letter) {
+    public byte[] create(LetterRequest letter) {
         Asserts.notNull(letter, "letter");
 
         List<byte[]> docs =

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/SampleData.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 
 import java.io.IOException;
 
@@ -14,8 +14,8 @@ import static java.util.Collections.singletonList;
 
 public final class SampleData {
 
-    public static Letter letter() throws IOException {
-        return new Letter(
+    public static LetterRequest letter() throws IOException {
+        return new LetterRequest(
             singletonList(
                 new Document(
                     Resources.toString(getResource("template.html"), UTF_8),

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.reform.sendletter.exception.ConnectionException;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.services.AuthService;
 import uk.gov.hmcts.reform.sendletter.services.LetterService;
 
@@ -51,21 +51,21 @@ public class SendLetterControllerTest {
         UUID letterId = UUID.randomUUID();
 
         given(authService.authenticate("auth-header-value")).willReturn("service-name");
-        given(letterService.send(any(Letter.class), anyString())).willReturn(letterId);
+        given(letterService.send(any(LetterRequest.class), anyString())).willReturn(letterId);
 
         sendLetter(readResource("letter.json"))
             .andExpect(status().isOk())
             .andExpect(content().json("{\"letter_id\":" + letterId + "}"));
 
         verify(authService).authenticate("auth-header-value");
-        verify(letterService).send(any(Letter.class), eq("service-name"));
+        verify(letterService).send(any(LetterRequest.class), eq("service-name"));
         verifyNoMoreInteractions(authService, letterService);
     }
 
     @Test
     public void should_return_connection_exception_when_service_fails_due_to_thread_interruption() throws Exception {
         given(authService.authenticate("auth-header-value")).willReturn("service-name");
-        given(letterService.send(any(Letter.class), anyString()))
+        given(letterService.send(any(LetterRequest.class), anyString()))
             .willThrow(
                 new ConnectionException("Unable to connect to Azure service bus",
                     new InterruptedException())
@@ -81,14 +81,14 @@ public class SendLetterControllerTest {
 
 
         verify(authService).authenticate("auth-header-value");
-        verify(letterService).send(any(Letter.class), anyString());
+        verify(letterService).send(any(LetterRequest.class), anyString());
         verifyNoMoreInteractions(authService, letterService);
     }
 
     @Test
     public void should_return_400_bad_request_when_service_fails_to_serialize_letter() throws Exception {
         given(authService.authenticate("auth-header-value")).willReturn("service-name");
-        willThrow(JsonProcessingException.class).given(letterService).send(any(Letter.class), anyString());
+        willThrow(JsonProcessingException.class).given(letterService).send(any(LetterRequest.class), anyString());
 
         sendLetter(readResource("letter.json"))
             .andExpect(status().isBadRequest())
@@ -105,7 +105,7 @@ public class SendLetterControllerTest {
     public void should_return_400_client_error_when_invalid_letter_is_sent() throws Exception {
         sendLetter("").andExpect(status().isBadRequest());
 
-        verify(letterService, never()).send(any(Letter.class), anyString());
+        verify(letterService, never()).send(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -115,7 +115,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents\",\"message\":\"size must be between 1 and 10\"}]}"));
 
-        verify(letterService, never()).send(any(Letter.class), anyString());
+        verify(letterService, never()).send(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"type\",\"message\":\"may not be empty\"}]}"));
 
-        verify(letterService, never()).send(any(Letter.class), anyString());
+        verify(letterService, never()).send(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents[0].template\",\"message\":\"may not be empty\"}]}"));
 
-        verify(letterService, never()).send(any(Letter.class), anyString());
+        verify(letterService, never()).send(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -146,7 +146,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents[0].values\",\"message\":\"may not be empty\"}]}"));
 
-        verify(letterService, never()).send(any(Letter.class), anyString());
+        verify(letterService, never()).send(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -157,7 +157,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents\",\"message\":\"size must be between 1 and 10\"}]}"));
 
-        verify(letterService, never()).send(any(Letter.class), anyString());
+        verify(letterService, never()).send(any(LetterRequest.class), anyString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterChecksumGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterChecksumGeneratorTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.sendletter.services;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
-import uk.gov.hmcts.reform.sendletter.model.in.Letter;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +13,7 @@ public class LetterChecksumGeneratorTest {
     @Test
     public void should_return_same_md5_checksum_hex_for_same_letter_objects() {
 
-        Letter letter1 = new Letter(
+        LetterRequest letter1 = new LetterRequest(
             singletonList(new Document(
                 "cmc-template",
                 ImmutableMap.of(
@@ -28,7 +28,7 @@ public class LetterChecksumGeneratorTest {
             )
         );
 
-        Letter letter2 = new Letter(
+        LetterRequest letter2 = new LetterRequest(
             singletonList(new Document(
                 "cmc-template",
                 ImmutableMap.of(
@@ -50,7 +50,7 @@ public class LetterChecksumGeneratorTest {
     @Test
     public void should_return_different_md5_checksum_hex_for_different_letter_objects() {
 
-        Letter letter1 = new Letter(
+        LetterRequest letter1 = new LetterRequest(
             singletonList(new Document(
                 "cmc-template",
                 ImmutableMap.of(
@@ -64,7 +64,7 @@ public class LetterChecksumGeneratorTest {
             )
         );
 
-        Letter letter2 = new Letter(
+        LetterRequest letter2 = new LetterRequest(
             singletonList(new Document(
                 "cmc-template",
                 ImmutableMap.of(


### PR DESCRIPTION
Just clears the full package access to letter entity and removes redundant UUID generation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
