### PR TITLE
Revert "Avoid EmptyResultDataAccessException"

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/LetterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/LetterTest.java
@@ -88,7 +88,7 @@ public class LetterTest {
         Letter second = getTestLetter("different");
         repository.save(second);
 
-        Letter found = repository.findOptionalByIdAndService(second.getId(), second.getService()).get();
+        Letter found = repository.findByIdAndService(second.getId(), second.getService()).get();
         assertThat(found.getId()).isEqualTo(second.getId());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -50,7 +50,7 @@ public class UploadLettersTaskTest {
             // Ensure the letter is marked as uploaded in the database.
             // Clear the JPA cache to force a read.
             entityManager.clear();
-            Letter l = repository.findOptionalById(id).get();
+            Letter l = repository.findById(id).get();
             assertThat(l.getState()).isEqualTo(LetterState.Uploaded);
             assertThat(l.getSentToPrintAt()).isNotNull();
             assertThat(l.getPrintedAt()).isNull();

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -14,8 +14,7 @@ public interface LetterRepository extends JpaRepository<Letter, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Stream<Letter> findByState(LetterState state);
 
+    Optional<Letter> findById(UUID id);
 
-    Optional<Letter> findOptionalById(UUID id);
-
-    Optional<Letter> findOptionalByIdAndService(UUID id, String service);
+    Optional<Letter> findByIdAndService(UUID id, String service);
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -47,7 +47,7 @@ public class LetterService {
 
     public LetterStatus getStatus(UUID id, String serviceName) {
         Letter letter = letterRepository
-            .findOptionalByIdAndService(id, serviceName)
+            .findByIdAndService(id, serviceName)
             .orElseThrow(() -> new LetterNotFoundException(id));
 
         return new LetterStatus(


### PR DESCRIPTION
Reverts hmcts/send-letter-service#29

Premature assumption that documentation is the one and only correct way do optional types