### PR TITLE
Fix intermittent FTP TransportException in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,8 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc', version: springBootVersion
   compile("org.springframework.boot:spring-boot-starter-data-jpa")
   compile group: 'com.vladmihalcea', name: 'hibernate-types-5', version: '2.1.1'
+  compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.55'
+  compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.55'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
   testCompile group: 'com.google.guava', name: 'guava', version: '23.4-jre'


### PR DESCRIPTION
### Change description ###

A few of us have seen intermittent errors during ftp related tests: `net.schmizz.sshj.transport.TransportException: Unable to reach a settlement: [] and []`

I believe this to be caused by TestContainers, on which I
raised a [bug.](https://github.com/testcontainers/testcontainers-java/issues/626)

We can work around it by removing the problematic shaded SecurityProvider that TestContainers adds and adding one that is not shaded and is in an official signed BouncyCastle jar.
