### PR TITLE
Fix sonar warnings

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/FtpClient.java
@@ -150,7 +150,7 @@ public class FtpClient {
                     ssh.disconnect();
                 }
             } catch (IOException e) {
-                logger.warn("Error closing ssh connection.");
+                logger.warn("Error closing ssh connection.", e);
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -27,7 +27,7 @@ import static java.time.LocalDateTime.now;
 public class UploadLettersTask {
     private static final Logger logger = LoggerFactory.getLogger(UploadLettersTask.class);
 
-    public static String SMOKE_TEST_LETTER_TYPE = "smoke_test";
+    public static final String SMOKE_TEST_LETTER_TYPE = "smoke_test";
 
     private final LetterRepository repo;
     private final Zipper zipper;


### PR DESCRIPTION
- missing `final` on constant
- logging exception