### PR TITLE
Upgrade jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '3.1.0'
   id 'com.github.ben-manes.versions' version '0.17.0'
   id 'org.sonarqube' version '2.6.1'
+  id 'info.solidsoft.pitest' version '1.3.0'
 }
 
 flyway {

--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,11 @@ pmd {
   ruleSetFiles = files("config/pmd/ruleset.xml")
 }
 
-jacocoTestReport {
+jacoco {
   toolVersion = "0.8.1"
+}
+
+jacocoTestReport {
   executionData(test, integration)
   reports {
     xml.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ pmd {
 }
 
 jacocoTestReport {
+  toolVersion = "0.8.1"
   executionData(test, integration)
   reports {
     xml.enabled = true


### PR DESCRIPTION
should not report on untested private constructors in utility classes now 🤞 