### PR TITLE
Remove the NOT NULL constraint from letters table

### DIFF
--- a/src/main/resources/db/migration/V006__Add_status_column.sql
+++ b/src/main/resources/db/migration/V006__Add_status_column.sql
@@ -12,6 +12,3 @@ SET
         'Posted'
     END
   );
-
-ALTER TABLE letters
-ALTER COLUMN status SET NOT NULL;


### PR DESCRIPTION
### Change description ###

This script is not applied in any environment, so it can still be changed.

The constraint can only be added after the replacement of the old system - otherwise we'll have downtime (producer unable to save letters).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
