### PR TITLE
Ensure tasks are not run concurrently

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.sendletter.tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
@@ -23,7 +21,6 @@ import java.util.Optional;
  * letters and sets posted letters as Posted in the database.
  */
 @Component
-@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
 public class MarkLettersPostedTask {
     private final LetterRepository repo;
     private final FtpClient ftpClient;
@@ -41,12 +38,6 @@ public class MarkLettersPostedTask {
         this.ftpClient = ftp;
         this.ftpAvailabilityChecker = checker;
         this.parser = parser;
-    }
-
-
-    @Scheduled(cron = "${tasks.mark-letters-posted}")
-    public void run() {
-        run(LocalTime.now());
     }
 
     public void run(LocalTime now) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/Task.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/Task.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.sendletter.tasks;
+
+public enum Task {
+    UploadLetters,
+    MarkLettersPosted;
+
+    long getLockId() {
+        return ordinal();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/TaskSchedule.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/TaskSchedule.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.sendletter.tasks;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
+import java.time.LocalTime;
+import javax.sql.DataSource;
+
+@Component
+@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
+public class TaskSchedule {
+    private final MarkLettersPostedTask markPosted;
+    private final UploadLettersTask upload;
+    private final DataSource dataSource;
+
+    public TaskSchedule(UploadLettersTask upload, MarkLettersPostedTask post, DataSource source) {
+        this.upload = upload;
+        this.markPosted = post;
+        this.dataSource = source;
+    }
+
+    @Scheduled(fixedDelayString = "${tasks.upload-letters}")
+    public void uploadLetters() throws SQLException {
+        tryRun(Task.UploadLetters, upload::run);
+    }
+
+    @Scheduled(cron = "${tasks.mark-letters-posted}")
+    public void markPosted() throws SQLException {
+        tryRun(Task.MarkLettersPosted, () -> markPosted.run(LocalTime.now()));
+    }
+
+    private void tryRun(Task task, Runnable runnable) throws SQLException {
+        SerialTaskRunner.get(dataSource).tryRun(task.getLockId(), runnable);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.sendletter.tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
@@ -28,7 +26,6 @@ import java.util.Objects;
 import static java.time.LocalDateTime.now;
 
 @Component
-@ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
 public class UploadLettersTask {
     private static final Logger logger = LoggerFactory.getLogger(UploadLettersTask.class);
 
@@ -52,7 +49,6 @@ public class UploadLettersTask {
         this.availabilityChecker = availabilityChecker;
     }
 
-    @Scheduled(fixedDelayString = "${tasks.upload-letters}")
     @Transactional
     public void run() {
         logger.info("Started letter upload job");


### PR DESCRIPTION
### Change description ###

Add the TaskSchedule that is responsible for scheduling of tasks, making use of the SerialTaskRunner to ensure that tasks are not run concurrently.

This approach was taken to avoid making our existing tasks depend on the SerialTaskRunner (and the refactoring of code/tests that would be required).

The TaskSchedule composes our existing tasks with the SerialTaskRunner to ensure that tasks are not run concurrently.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
