### PR TITLE
Namespace Postgres Advisory locks to avoid collisions

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/Task.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/Task.java
@@ -4,7 +4,7 @@ public enum Task {
     UploadLetters,
     MarkLettersPosted;
 
-    long getLockId() {
+    int getLockId() {
         return ordinal();
     }
 }


### PR DESCRIPTION
### Change description ###

Advisory locks are referenced by number, so we must avoid collisions eg. lock '0' being used for two different purposes within the same application by different libraries.

Instead of referring to locks as a single long, we can refer to them as two ints and treat the first int as a namespace, for which we use a random constant in this change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
