### PR TITLE
Add unit test for pdf creator

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
@@ -33,7 +34,7 @@ public class LetterService {
 
     private static final Logger log = LoggerFactory.getLogger(LetterService.class);
 
-    private final PdfCreator pdfCreator = new PdfCreator(new DuplexPreparator());
+    private final PdfCreator pdfCreator = new PdfCreator(new DuplexPreparator(), new HTMLToPDFConverter()::convert);
     private final LetterRepository letterRepository;
     private final Zipper zipper;
     private final ObjectMapper mapper;

--- a/src/main/java/uk/gov/hmcts/reform/slc/config/PdfConversionConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/config/PdfConversionConfig.java
@@ -10,7 +10,6 @@ public class PdfConversionConfig {
 
     @Bean
     public IHtmlToPdfConverter htmlToPdfConverter() {
-        HTMLToPDFConverter converter = new HTMLToPDFConverter();
-        return converter::convert;
+        return new HTMLToPDFConverter()::convert;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/slc/config/PdfConversionConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/config/PdfConversionConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.slc.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
+import uk.gov.hmcts.reform.slc.services.steps.getpdf.IHtmlToPdfConverter;
+
+@Configuration
+public class PdfConversionConfig {
+
+    @Bean
+    public IHtmlToPdfConverter htmlToPdfConverter() {
+        HTMLToPDFConverter converter = new HTMLToPDFConverter();
+        return converter::convert;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/IHtmlToPdfConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/IHtmlToPdfConverter.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.slc.services.steps.getpdf;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public interface IHtmlToPdfConverter extends BiFunction<byte[], Map<String, Object>, byte[]> {
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.slc.services.steps.getpdf;
 
 import org.apache.http.util.Asserts;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
 import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.slc.services.steps.getpdf.duplex.DuplexPreparator;
@@ -15,10 +14,11 @@ import static java.util.stream.Collectors.toList;
 public class PdfCreator {
 
     private final DuplexPreparator duplexPreparator;
-    private static HTMLToPDFConverter converter = new HTMLToPDFConverter();
+    private IHtmlToPdfConverter converter;
 
-    public PdfCreator(DuplexPreparator duplexPreparator) {
+    public PdfCreator(DuplexPreparator duplexPreparator, IHtmlToPdfConverter converter) {
         this.duplexPreparator = duplexPreparator;
+        this.converter = converter;
     }
 
     public byte[] create(LetterRequest letter) {
@@ -36,7 +36,7 @@ public class PdfCreator {
 
     private byte[] generatePdf(Document document) {
         synchronized (PdfCreator.class) {
-            return converter.convert(document.template.getBytes(), document.values);
+            return converter.apply(document.template.getBytes(), document.values);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
@@ -14,7 +14,7 @@ import static java.util.stream.Collectors.toList;
 public class PdfCreator {
 
     private final DuplexPreparator duplexPreparator;
-    private IHtmlToPdfConverter converter;
+    private final IHtmlToPdfConverter converter;
 
     public PdfCreator(DuplexPreparator duplexPreparator, IHtmlToPdfConverter converter) {
         this.duplexPreparator = duplexPreparator;

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.slc.services.steps.getpdf;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sendletter.model.in.Document;
+import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
+import uk.gov.hmcts.reform.slc.services.steps.getpdf.duplex.DuplexPreparator;
+
+import java.io.InputStream;
+
+import static com.google.common.io.Resources.getResource;
+import static com.google.common.io.Resources.toByteArray;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PdfCreatorTest {
+
+    @Mock private DuplexPreparator duplexPreparator;
+    @Mock private IHtmlToPdfConverter converter;
+
+    private PdfCreator pdfCreator;
+
+    @Before
+    public void setUp() {
+        pdfCreator = new PdfCreator(this.duplexPreparator, this.converter);
+    }
+
+    @Test
+    public void should_require_letter_to_not_be_null() {
+        assertThatThrownBy(() -> pdfCreator.create(null))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("letter");
+    }
+
+    @Test
+    public void should_return_a_merged_pdf_when_letter_consists_of_multiple_documents() throws Exception {
+        byte[] test1Pdf = toByteArray(getResource("test1.pdf"));
+        byte[] test2Pdf = toByteArray(getResource("test2.pdf"));
+        byte[] expectedMergedPdf = toByteArray(getResource("merged.pdf"));
+
+        given(duplexPreparator.prepare(test1Pdf)).willReturn(test1Pdf);
+        given(duplexPreparator.prepare(test2Pdf)).willReturn(test2Pdf);
+
+        given(converter.apply(eq("t1".getBytes()), any())).willReturn(test1Pdf);
+        given(converter.apply(eq("t2".getBytes()), any())).willReturn(test2Pdf);
+
+        LetterRequest letter = new LetterRequest(
+            asList(
+                new Document("t1", emptyMap()),
+                new Document("t2", emptyMap())
+            ),
+            "type",
+            null
+        );
+
+        // when
+        byte[] pdfContent = pdfCreator.create(letter);
+
+        // then
+        InputStream actualPdfPage1 = getPdfPageContents(pdfContent, 0);
+        InputStream actualPdfPage2 = getPdfPageContents(pdfContent, 1);
+
+        InputStream expectedPdfPage1 = getPdfPageContents(expectedMergedPdf, 0);
+        InputStream expectedPdfPage2 = getPdfPageContents(expectedMergedPdf, 1);
+
+        assertThat(actualPdfPage1).hasSameContentAs(expectedPdfPage1);
+        assertThat(actualPdfPage2).hasSameContentAs(expectedPdfPage2);
+
+        verify(duplexPreparator, times(2)).prepare(any(byte[].class));
+    }
+
+    private InputStream getPdfPageContents(byte[] pdf, int pageNumber) throws Exception {
+        return PDDocument.load(pdf).getPage(pageNumber).getContents();
+    }
+
+}


### PR DESCRIPTION
Mostly copied from https://github.com/hmcts/send-letter-consumer-service/blob/master/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
with slight changes:
- no calls to pdf-service api
- no calls to app insights