### PR TITLE
Remove row level locking from LetterRepository

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.sendletter.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 import java.sql.Timestamp;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
-import javax.persistence.LockModeType;
 
 public interface LetterRepository extends JpaRepository<Letter, UUID> {
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -11,9 +11,6 @@ import javax.persistence.LockModeType;
 
 public interface LetterRepository extends JpaRepository<Letter, UUID> {
 
-    // This lockmode locks the returned rows
-    // for both reading and writing.
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Stream<Letter> findByStatus(LetterStatus status);
 
     Stream<Letter> findByStatusAndSentToPrintAtBefore(LetterStatus status, Timestamp before);


### PR DESCRIPTION
### Change description ###

Scheduled tasks are now locked to stop them running concurrently, so we no longer need to lock rows for reading and updating when running the UploadLetters task.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
