### PR TITLE
Fix logged event in response exception handler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.4.2'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.6.0'
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.3.0'
   compile group: 'uk.gov.hmcts.reform', name: 'pdf-generator', version: '1.0.2'
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
+import uk.gov.hmcts.reform.sendletter.exception.InternalServerException;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
 import uk.gov.hmcts.reform.sendletter.model.out.errors.FieldError;
@@ -59,7 +61,7 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(InvalidTokenException.class)
     protected ResponseEntity<Void> handleInvalidTokenException(InvalidTokenException exc) {
-        log.warn(exc.getMessage(), exc);
+        log.warn(exc.getMessage(), new UnauthenticatedException(exc));
         return status(UNAUTHORIZED).build();
     }
 
@@ -82,7 +84,13 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<Void> handleInternalException(Exception exc) {
-        log.error(exc.getMessage(), exc);
+        Throwable exception = exc;
+
+        if (!(exc instanceof AbstractLoggingException)) {
+            exception = new InternalServerException(exc);
+        }
+
+        log.error(exc.getMessage(), exception);
         return status(INTERNAL_SERVER_ERROR).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
@@ -61,7 +61,7 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(InvalidTokenException.class)
     protected ResponseEntity<Void> handleInvalidTokenException(InvalidTokenException exc) {
-        log.warn(exc.getMessage(), new UnauthenticatedException(exc));
+        log.warn(exc.getMessage(), exc);
         return status(UNAUTHORIZED).build();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/InternalServerException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/InternalServerException.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.sendletter.exception;
+
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
+
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
+public class InternalServerException extends UnknownErrorCodeException {
+
+    public InternalServerException(Throwable cause) {
+        super(AlertLevel.P1, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnauthenticatedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnauthenticatedException.java
@@ -11,13 +11,4 @@ public class UnauthenticatedException extends UnknownErrorCodeException {
     public UnauthenticatedException(String message) {
         super(AlertLevel.P3, message);
     }
-
-    /**
-     * Used to wrap InvalidTokenException thrown by authorisation library.
-     *
-     * @param cause Original InvalidTokenException
-     */
-    public UnauthenticatedException(Throwable cause) {
-        super(AlertLevel.P4, cause);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnauthenticatedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnauthenticatedException.java
@@ -11,4 +11,13 @@ public class UnauthenticatedException extends UnknownErrorCodeException {
     public UnauthenticatedException(String message) {
         super(AlertLevel.P3, message);
     }
+
+    /**
+     * Used to wrap InvalidTokenException thrown by authorisation library.
+     *
+     * @param cause Original InvalidTokenException
+     */
+    public UnauthenticatedException(Throwable cause) {
+        super(AlertLevel.P4, cause);
+    }
 }


### PR DESCRIPTION
Report log events to AppInsights with correct implementation avoiding "wrong implementation" errors magically appearing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
