### PR TITLE
Add dependency tracking for service authentication

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependency.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependency.java
@@ -6,6 +6,11 @@ package uk.gov.hmcts.reform.sendletter.logging;
 final class AppDependency {
 
     /**
+     * Service auth provider.
+     */
+    static final String AUTH_SERVICE = "AuthService";
+
+    /**
      * Ftp client.
      */
     static final String FTP_CLIENT = "FtpClient";

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependencyCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependencyCommand.java
@@ -3,6 +3,11 @@ package uk.gov.hmcts.reform.sendletter.logging;
 final class AppDependencyCommand {
 
     /**
+     * Authenticate service header and retrieve it's name.
+     */
+    static final String AUTH_SERVICE_HEADER = "AuthenticateServiceHeader";
+
+    /**
      * File uploaded to ftp.
      */
     static final String FTP_FILE_UPLOADED = "FtpFileUploaded";

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
@@ -25,6 +25,15 @@ public class AppInsights extends AbstractAppInsights {
 
     // dependencies
 
+    public void trackServiceAuthentication(java.time.Duration duration, boolean success) {
+        telemetry.trackDependency(
+            AppDependency.AUTH_SERVICE,
+            AppDependencyCommand.AUTH_SERVICE_HEADER,
+            new Duration(duration.toMillis()),
+            success
+        );
+    }
+
     public void trackFtpUpload(java.time.Duration duration, boolean success) {
         telemetry.trackDependency(
             AppDependency.FTP_CLIENT,

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
@@ -6,13 +6,11 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.logging.appinsights.AbstractAppInsights;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 @Component
 public class AppInsights extends AbstractAppInsights {
@@ -27,38 +25,13 @@ public class AppInsights extends AbstractAppInsights {
 
     // dependencies
 
-    private void trackDependency(String dependency, String command, Instant start, Instant end, boolean success) {
-        java.time.Duration duration = java.time.Duration.between(start, end);
-
-        telemetry.trackDependency(dependency, command, new Duration(duration.toMillis()), success);
-    }
-
-    public String trackServiceAuthentication(Supplier<String> serviceName) {
-        Instant start = Instant.now();
-
-        try {
-            String name = serviceName.get();
-
-            trackDependency(
-                AppDependency.AUTH_SERVICE,
-                AppDependencyCommand.AUTH_SERVICE_HEADER,
-                start,
-                Instant.now(),
-                true
-            );
-
-            return name;
-        } catch (Throwable exception) {
-            trackDependency(
-                AppDependency.AUTH_SERVICE,
-                AppDependencyCommand.AUTH_SERVICE_HEADER,
-                start,
-                Instant.now(),
-                false
-            );
-
-            throw exception;
-        }
+    public void trackServiceAuthentication(java.time.Duration duration, boolean success) {
+        telemetry.trackDependency(
+            AppDependency.AUTH_SERVICE,
+            AppDependencyCommand.AUTH_SERVICE_HEADER,
+            new Duration(duration.toMillis()),
+            success
+        );
     }
 
     public void trackFtpUpload(java.time.Duration duration, boolean success) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/AuthService.java
@@ -3,21 +3,39 @@ package uk.gov.hmcts.reform.sendletter.services;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
+import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
+
+import java.time.Duration;
+import java.time.Instant;
 
 @Component
 public class AuthService {
 
     private final AuthTokenValidator authTokenValidator;
+    private final AppInsights insights;
 
-    public AuthService(AuthTokenValidator authTokenValidator) {
+    public AuthService(AuthTokenValidator authTokenValidator, AppInsights insights) {
         this.authTokenValidator = authTokenValidator;
+        this.insights = insights;
     }
 
     public String authenticate(String authHeader) {
         if (authHeader == null) {
             throw new UnauthenticatedException("Missing ServiceAuthorization header");
         } else {
-            return authTokenValidator.getServiceName(authHeader);
+            Instant start = Instant.now();
+
+            try {
+                String serviceName = authTokenValidator.getServiceName(authHeader);
+
+                insights.trackServiceAuthentication(Duration.between(start, Instant.now()), true);
+
+                return serviceName;
+            } catch (Throwable exception) {
+                insights.trackServiceAuthentication(Duration.between(start, Instant.now()), false);
+
+                throw exception;
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/AuthService.java
@@ -5,9 +5,6 @@ import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 
-import java.time.Duration;
-import java.time.Instant;
-
 @Component
 public class AuthService {
 
@@ -23,19 +20,7 @@ public class AuthService {
         if (authHeader == null) {
             throw new UnauthenticatedException("Missing ServiceAuthorization header");
         } else {
-            Instant start = Instant.now();
-
-            try {
-                String serviceName = authTokenValidator.getServiceName(authHeader);
-
-                insights.trackServiceAuthentication(Duration.between(start, Instant.now()), true);
-
-                return serviceName;
-            } catch (Throwable exception) {
-                insights.trackServiceAuthentication(Duration.between(start, Instant.now()), false);
-
-                throw exception;
-            }
+            return insights.trackServiceAuthentication(() -> authTokenValidator.getServiceName(authHeader));
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/AuthService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/AuthService.java
@@ -5,6 +5,9 @@ import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 
+import java.time.Duration;
+import java.time.Instant;
+
 @Component
 public class AuthService {
 
@@ -20,7 +23,19 @@ public class AuthService {
         if (authHeader == null) {
             throw new UnauthenticatedException("Missing ServiceAuthorization header");
         } else {
-            return insights.trackServiceAuthentication(() -> authTokenValidator.getServiceName(authHeader));
+            Instant start = Instant.now();
+
+            try {
+                String serviceName = authTokenValidator.getServiceName(authHeader);
+
+                insights.trackServiceAuthentication(Duration.between(start, Instant.now()), true);
+
+                return serviceName;
+            } catch (Throwable exception) {
+                insights.trackServiceAuthentication(Duration.between(start, Instant.now()), false);
+
+                throw exception;
+            }
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
@@ -65,6 +65,19 @@ public class AppInsightsTest {
     // dependencies
 
     @Test
+    public void should_track_service_authentication() {
+        insights.trackServiceAuthentication(TIME_TOOK, true);
+        insights.trackServiceAuthentication(TIME_TOOK, false);
+
+        verify(telemetry, times(2)).trackDependency(
+            eq(AppDependency.AUTH_SERVICE),
+            eq(AppDependencyCommand.AUTH_SERVICE_HEADER),
+            any(Duration.class),
+            anyBoolean()
+        );
+    }
+
+    @Test
     public void should_track_ftp_upload() {
         insights.trackFtpUpload(TIME_TOOK, true);
         insights.trackFtpUpload(TIME_TOOK, false);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
@@ -11,7 +11,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 
 import java.sql.Timestamp;
@@ -22,7 +21,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
@@ -68,12 +66,9 @@ public class AppInsightsTest {
 
     @Test
     public void should_track_service_authentication() {
-        insights.trackServiceAuthentication(() -> "service name");
-        Throwable exception = catchThrowable(() -> insights.trackServiceAuthentication(() -> {
-            throw new InvalidTokenException("dummy token", null);
-        }));
+        insights.trackServiceAuthentication(TIME_TOOK, true);
+        insights.trackServiceAuthentication(TIME_TOOK, false);
 
-        assertThat(exception).isInstanceOf(InvalidTokenException.class);
         verify(telemetry, times(2)).trackDependency(
             eq(AppDependency.AUTH_SERVICE),
             eq(AppDependencyCommand.AUTH_SERVICE_HEADER),

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
@@ -11,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 
 import java.sql.Timestamp;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
@@ -66,9 +68,12 @@ public class AppInsightsTest {
 
     @Test
     public void should_track_service_authentication() {
-        insights.trackServiceAuthentication(TIME_TOOK, true);
-        insights.trackServiceAuthentication(TIME_TOOK, false);
+        insights.trackServiceAuthentication(() -> "service name");
+        Throwable exception = catchThrowable(() -> insights.trackServiceAuthentication(() -> {
+            throw new InvalidTokenException("dummy token", null);
+        }));
 
+        assertThat(exception).isInstanceOf(InvalidTokenException.class);
         verify(telemetry, times(2)).trackDependency(
             eq(AppDependency.AUTH_SERVICE),
             eq(AppDependencyCommand.AUTH_SERVICE_HEADER),

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/AuthServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/AuthServiceTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.reform.sendletter.services;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
+import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
+import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthServiceTest {
+
+    private static final String SERVICE_HEADER = "some-header";
+
+    @Mock
+    private AuthTokenValidator validator;
+
+    @Mock
+    private AppInsights insights;
+
+    private AuthService service;
+
+    @Before
+    public void setUp() {
+        service = new AuthService(validator, insights);
+    }
+
+    @After
+    public void tearDown() {
+        reset(validator, insights);
+    }
+
+    @Test
+    public void should_throw_missing_header_exception_when_it_is_null() {
+        // when
+        Throwable exception = catchThrowable(() -> service.authenticate(null));
+
+        // then
+        assertThat(exception)
+            .isInstanceOf(UnauthenticatedException.class)
+            .hasMessage("Missing ServiceAuthorization header");
+
+        // and
+        verify(validator, never()).getServiceName(anyString());
+        verify(insights, never()).trackServiceAuthentication(any(Duration.class), anyBoolean());
+    }
+
+    @Test
+    public void should_track_failure_in_service_dependency_when_invalid_token_received() {
+        // given
+        willThrow(InvalidTokenException.class).given(validator).getServiceName(anyString());
+
+        // when
+        Throwable exception = catchThrowable(() -> service.authenticate(SERVICE_HEADER));
+
+        // then
+        assertThat(exception).isInstanceOf(InvalidTokenException.class);
+
+        // and
+        verify(insights).trackServiceAuthentication(any(Duration.class), eq(false));
+    }
+
+    @Test
+    public void should_track_successful_service_dependency_when_valid_token_received() {
+        // given
+        given(validator.getServiceName(SERVICE_HEADER)).willReturn("some-service");
+
+        // when
+        String serviceName = service.authenticate(SERVICE_HEADER);
+
+        // then
+        assertThat(serviceName).isEqualTo("some-service");
+
+        // and
+        verify(insights).trackServiceAuthentication(any(Duration.class), eq(true));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/AuthServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/AuthServiceTest.java
@@ -1,8 +1,5 @@
 package uk.gov.hmcts.reform.sendletter.services;
 
-import com.microsoft.applicationinsights.TelemetryClient;
-import com.microsoft.applicationinsights.telemetry.Duration;
-import com.microsoft.applicationinsights.telemetry.TelemetryContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +10,8 @@ import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -35,21 +34,18 @@ public class AuthServiceTest {
     private AuthTokenValidator validator;
 
     @Mock
-    private TelemetryClient telemetry;
+    private AppInsights insights;
 
     private AuthService service;
 
     @Before
     public void setUp() {
-        TelemetryContext context = new TelemetryContext();
-        context.setInstrumentationKey("some-key");
-        given(telemetry.getContext()).willReturn(context);
-        service = new AuthService(validator, new AppInsights(telemetry));
+        service = new AuthService(validator, insights);
     }
 
     @After
     public void tearDown() {
-        reset(validator, telemetry);
+        reset(validator, insights);
     }
 
     @Test
@@ -64,7 +60,7 @@ public class AuthServiceTest {
 
         // and
         verify(validator, never()).getServiceName(anyString());
-        verify(telemetry, never()).trackDependency(anyString(), anyString(), any(Duration.class), anyBoolean());
+        verify(insights, never()).trackServiceAuthentication(any(Duration.class), anyBoolean());
     }
 
     @Test
@@ -79,7 +75,7 @@ public class AuthServiceTest {
         assertThat(exception).isInstanceOf(InvalidTokenException.class);
 
         // and
-        verify(telemetry).trackDependency(anyString(), anyString(), any(Duration.class), eq(false));
+        verify(insights).trackServiceAuthentication(any(Duration.class), eq(false));
     }
 
     @Test
@@ -94,6 +90,6 @@ public class AuthServiceTest {
         assertThat(serviceName).isEqualTo("some-service");
 
         // and
-        verify(telemetry).trackDependency(anyString(), anyString(), any(Duration.class), eq(true));
+        verify(insights).trackServiceAuthentication(any(Duration.class), eq(true));
     }
 }


### PR DESCRIPTION
We never tracked service authentication as a dependency before. Adding unit test for sanity check

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
