### PR TITLE
Scheduled task interval cleanup

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
@@ -86,14 +86,16 @@ public class EndToEndTest {
 
             // Wait for letter to be uploaded.
             await().atMost(15, SECONDS).untilAsserted(
-                () -> assertThat(server.lettersFolder.listFiles()).as("No letters uploaded!").isNotEmpty());
+                () -> assertThat(server.lettersFolder.listFiles()).as("No letters uploaded!").isNotEmpty()
+            );
 
             // Generate Xerox report.
             createXeroxReport(server);
 
             // The report should be processed and the letter marked posted.
             await().atMost(15, SECONDS).untilAsserted(
-                () -> assertThat(letterHasBeenPosted()).as("Letter not posted").isTrue());
+                () -> assertThat(letterHasBeenPosted()).as("Letter not posted").isTrue()
+            );
         }
 
         verify(insights, atLeastOnce()).trackDependency(any(ProceedingJoinPoint.class), dependencyCaptor.capture());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
@@ -85,14 +85,14 @@ public class EndToEndTest {
                 .andReturn();
 
             // Wait for letter to be uploaded.
-            await().atMost(60, SECONDS).untilAsserted(
+            await().atMost(15, SECONDS).untilAsserted(
                 () -> assertThat(server.lettersFolder.listFiles()).as("No letters uploaded!").isNotEmpty());
 
             // Generate Xerox report.
             createXeroxReport(server);
 
             // The report should be processed and the letter marked posted.
-            await().atMost(60, SECONDS).untilAsserted(
+            await().atMost(15, SECONDS).untilAsserted(
                 () -> assertThat(letterHasBeenPosted()).as("Letter not posted").isTrue());
         }
 

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -41,7 +41,7 @@ ftp:
 scheduling.enabled: false
 
 tasks:
-  upload-letters: ${UPLOAD_LETTERS_INTERVAL:1}
+  upload-letters: ${UPLOAD_LETTERS_INTERVAL:1000} #
   # Run every second.
   mark-letters-posted: ${FTP_REPORTS_CRON:*/1 * * * * *}
   stale-letters-report: ${FTP_REPORTS_CRON:*/1 * * * * *}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -41,7 +41,7 @@ ftp:
 scheduling.enabled: false
 
 tasks:
-  upload-letters: ${UPLOAD_LETTERS_INTERVAL:1000} #
+  upload-letters-interval-ms: ${UPLOAD_LETTERS_INTERVAL:1000} #
   # Run every second.
   mark-letters-posted: ${FTP_REPORTS_CRON:*/1 * * * * *}
   stale-letters-report: ${FTP_REPORTS_CRON:*/1 * * * * *}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -41,7 +41,7 @@ ftp:
 scheduling.enabled: false
 
 tasks:
-  upload-letters-interval-ms: ${UPLOAD_LETTERS_INTERVAL:1000} #
+  upload-letters-interval-ms: ${UPLOAD_LETTERS_INTERVAL:1000}
   # Run every second.
   mark-letters-posted: ${FTP_REPORTS_CRON:*/1 * * * * *}
   stale-letters-report: ${FTP_REPORTS_CRON:*/1 * * * * *}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/TaskSchedule.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/TaskSchedule.java
@@ -33,7 +33,7 @@ public class TaskSchedule {
         this.dataSource = source;
     }
 
-    @Scheduled(fixedDelayString = "${tasks.upload-letters}")
+    @Scheduled(fixedDelayString = "${tasks.upload-letters-interval-ms}")
     public void uploadLetters() {
         tryRun(Task.UploadLetters, upload::run);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,8 +59,7 @@ ftp:
 scheduling.enabled: false
 
 tasks:
-  # Interval is in milliseconds.
-  upload-letters: ${UPLOAD_LETTERS_INTERVAL:30000}
+  upload-letters-interval-ms: ${UPLOAD_LETTERS_INTERVAL:30000}
   mark-letters-posted: ${FTP_REPORTS_CRON:0 30 0 * * *}
   stale-letters-report: ${STALE_LETTERS_REPORT_CRON:0 30 1 * * *}
 


### PR DESCRIPTION
- increase upload task delay in integration tests (every 1sec instead of every 1ms (sic!)
- make config value name clearer
- reduce wait time in e2e test (failing test would run for full 2min, now 30sec)
- fix code formatting