### PR TITLE
Feature: PDF dependency

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
@@ -48,7 +48,7 @@ public class LetterServiceTest {
     @Before
     public void setUp() {
         service = new LetterService(
-            new PdfCreator(new DuplexPreparator(), new HTMLToPDFConverter()::convert),
+            new PdfCreator(new DuplexPreparator(), new PdfConverter(new HTMLToPDFConverter()::convert)),
             letterRepository,
             new Zipper(),
             new ObjectMapper(),

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
@@ -21,7 +21,7 @@ public class PdfCreatorTest {
 
     @Before
     public void setUp() {
-        this.pdfCreator = new PdfCreator(new DuplexPreparator(), new HTMLToPDFConverter()::convert);
+        this.pdfCreator = new PdfCreator(new DuplexPreparator(), new PdfConverter(new HTMLToPDFConverter()::convert));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.sendletter.helper.FtpHelper;
 import uk.gov.hmcts.reform.sendletter.services.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.LetterService;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
+import uk.gov.hmcts.reform.sendletter.services.PdfConverter;
 import uk.gov.hmcts.reform.sendletter.services.PdfCreator;
 import uk.gov.hmcts.reform.sendletter.services.util.DuplexPreparator;
 import uk.gov.hmcts.reform.sendletter.services.zip.Zipper;
@@ -51,7 +52,7 @@ public class UploadLettersTaskTest {
     public void setUp() {
         when(availabilityChecker.isFtpAvailable(any(LocalTime.class))).thenReturn(true);
         this.letterService = new LetterService(
-            new PdfCreator(new DuplexPreparator(), new HTMLToPDFConverter()::convert),
+            new PdfCreator(new DuplexPreparator(), new PdfConverter(new HTMLToPDFConverter()::convert)),
             repository,
             new Zipper(),
             new ObjectMapper(),

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependency.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependency.java
@@ -15,6 +15,11 @@ public final class AppDependency {
      */
     public static final String FTP_CLIENT = "FtpClient";
 
+    /**
+     * Pdf client.
+     */
+    public static final String PDF_CLIENT = "PdfClient";
+
     private AppDependency() {
         // utility class constructor
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependencyCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependencyCommand.java
@@ -22,6 +22,11 @@ public final class AppDependencyCommand {
      */
     public static final String FTP_REPORT_DELETE = "FtpReportDeleted";
 
+    /**
+     * Created PDF from template and properties.
+     */
+    public static final String PDF_CREATE = "PdfCreated";
+
     private AppDependencyCommand() {
         // utility class constructor
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.util.Asserts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.reform.pdf.generator.HTMLToPDFConverter;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
@@ -18,7 +16,6 @@ import uk.gov.hmcts.reform.sendletter.model.in.ILetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.in.LetterWithPdfsRequest;
 import uk.gov.hmcts.reform.sendletter.model.out.LetterStatus;
-import uk.gov.hmcts.reform.sendletter.services.util.DuplexPreparator;
 import uk.gov.hmcts.reform.sendletter.services.zip.Zipper;
 import uk.gov.hmcts.reform.slc.services.steps.getpdf.FileNameHelper;
 
@@ -53,23 +50,6 @@ public class LetterService {
         this.zipper = zipper;
         this.mapper = mapper;
         this.isEncryptionEnabled = isEncryptionEnabled;
-    }
-
-    // TODO: remove
-    @Autowired
-    public LetterService(
-        LetterRepository letterRepository,
-        Zipper zipper,
-        ObjectMapper mapper,
-        @Value("${encryption.enabled}") Boolean isEncryptionEnabled
-    ) {
-        this(
-            new PdfCreator(new DuplexPreparator(), new HTMLToPDFConverter()::convert),
-            letterRepository,
-            zipper,
-            mapper,
-            isEncryptionEnabled
-        );
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfConverter.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.sendletter.services;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sendletter.model.in.Document;
+import uk.gov.hmcts.reform.sendletter.services.util.IHtmlToPdfConverter;
+
+@Component
+public class PdfConverter {
+
+    private final IHtmlToPdfConverter converter;
+
+    public PdfConverter(IHtmlToPdfConverter converter) {
+        this.converter = converter;
+    }
+
+    public byte[] generatePdf(Document document) {
+        synchronized (PdfConverter.class) {
+            return converter.apply(document.template.getBytes(), document.values);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfConverter.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.reform.sendletter.services;
 
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sendletter.logging.AppDependency;
+import uk.gov.hmcts.reform.sendletter.logging.AppDependencyCommand;
+import uk.gov.hmcts.reform.sendletter.logging.Dependency;
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
 import uk.gov.hmcts.reform.sendletter.services.util.IHtmlToPdfConverter;
 
@@ -13,6 +16,7 @@ public class PdfConverter {
         this.converter = converter;
     }
 
+    @Dependency(value = AppDependency.PDF_CLIENT, command = AppDependencyCommand.PDF_CREATE)
     public byte[] generatePdf(Document document) {
         synchronized (PdfConverter.class) {
             return converter.apply(document.template.getBytes(), document.values);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfCreator.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sendletter.exception.InvalidPdfException;
 import uk.gov.hmcts.reform.sendletter.model.in.Document;
 import uk.gov.hmcts.reform.sendletter.services.util.DuplexPreparator;
-import uk.gov.hmcts.reform.sendletter.services.util.IHtmlToPdfConverter;
 
 import java.util.Base64;
 import java.util.List;
@@ -16,9 +15,9 @@ import static java.util.stream.Collectors.toList;
 public class PdfCreator {
 
     private final DuplexPreparator duplexPreparator;
-    private final IHtmlToPdfConverter converter;
+    private final PdfConverter converter;
 
-    public PdfCreator(DuplexPreparator duplexPreparator, IHtmlToPdfConverter converter) {
+    public PdfCreator(DuplexPreparator duplexPreparator, PdfConverter converter) {
         this.duplexPreparator = duplexPreparator;
         this.converter = converter;
     }
@@ -29,7 +28,7 @@ public class PdfCreator {
         List<byte[]> docs =
             documents
                 .stream()
-                .map(this::generatePdf)
+                .map(converter::generatePdf)
                 .map(duplexPreparator::prepare)
                 .collect(toList());
 
@@ -47,12 +46,6 @@ public class PdfCreator {
                 .collect(toList());
 
         return PdfMerger.mergeDocuments(docs);
-    }
-
-    private byte[] generatePdf(Document document) {
-        synchronized (PdfCreator.class) {
-            return converter.apply(document.template.getBytes(), document.values);
-        }
     }
 
     private byte[] decodePdf(String base64encodedPdf) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/PdfCreator.java
@@ -22,7 +22,7 @@ public class PdfCreator {
         this.converter = converter;
     }
 
-    public byte[] createFromTemplates(List<Document> documents) {
+    byte[] createFromTemplates(List<Document> documents) {
         Asserts.notNull(documents, "documents");
 
         List<byte[]> docs =
@@ -35,7 +35,7 @@ public class PdfCreator {
         return PdfMerger.mergeDocuments(docs);
     }
 
-    public byte[] createFromBase64Pdfs(List<String> base64encodedDocs) {
+    byte[] createFromBase64Pdfs(List<String> base64encodedDocs) {
         Asserts.notNull(base64encodedDocs, "base64encodedDocs");
 
         List<byte[]> docs =

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
@@ -37,7 +37,7 @@ public class PdfCreatorTest {
 
     @Before
     public void setUp() {
-        pdfCreator = new PdfCreator(this.duplexPreparator, this.converter);
+        pdfCreator = new PdfCreator(this.duplexPreparator, new PdfConverter(this.converter));
     }
 
     @Test


### PR DESCRIPTION
Notes:

- Remove extra constructor from letter service which is not used anymore
- Split Pdf creator to separate beans because Spring AOP cannot properly recognise proxied class method call with built-in `@Dependency`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
