### PR TITLE
Updated Encryption algorithm from 3DES to AES 256

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/encryption/PgpEncryptionUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/encryption/PgpEncryptionUtil.java
@@ -35,7 +35,7 @@ public final class PgpEncryptionUtil {
     }
 
     /**
-     * Encrypts the given byte array using PGP encryption using Triple DES algorithm.
+     * Encrypts the given byte array using PGP encryption using AES 256 algorithm.
      * This method assumes that the temporary volume is writable
      *
      * @param inputFile          input file byte array
@@ -121,7 +121,7 @@ public final class PgpEncryptionUtil {
         PGPPublicKey pgpPublicKey,
         boolean withIntegrityCheck
     ) {
-        BcPGPDataEncryptorBuilder dataEncryptor = new BcPGPDataEncryptorBuilder(PGPEncryptedData.TRIPLE_DES);
+        BcPGPDataEncryptorBuilder dataEncryptor = new BcPGPDataEncryptorBuilder(PGPEncryptedData.AES_256);
         dataEncryptor.setWithIntegrityPacket(withIntegrityCheck);
         dataEncryptor.setSecureRandom(new SecureRandom());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-228


### Change description ###

- Updated encryption algorithm from Triple DES to AES 256 as 3DES is very slow.

- Symantec also uses AES 256 by default as their encryption algorithm.

- Decryption should not be impacted because of this change.

- Tested Decryption with Symantec and BountyCastle API and works fine.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```