### PR TITLE
Build pushes to master only on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+branches:
+  only:
+    - master
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Currently, for every open PR (and push) there are 2 travis builds running.
(as both 'build pushed branches' and 'build pushed pull requests' are enabled)

This change should reduce number of builds to 1.

https://stackoverflow.com/a/31882307