### PR TITLE
Cleanup pdf file name generation

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
@@ -146,7 +146,7 @@ public class EndToEndTest {
     private UUID validateGettingLetterId(File file) {
         try {
             PdfHelper.validateZippedPdf(Files.readAllBytes(file.toPath()));
-            return FileNameHelper.extractId(file.getName());
+            return FileNameHelper.extractIdFromPdfName(file.getName());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/util/XeroxReportWriter.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/util/XeroxReportWriter.java
@@ -26,7 +26,7 @@ public final class XeroxReportWriter {
         List<List<String>> records = letterIds.map(x -> Lists.newArrayList(
             "01-01-2018",
             "10:30",
-            FileNameHelper.generateName("aType", "aService", x, "pdf")
+            FileNameHelper.generatePdfName("aType", "aService", x, "pdf")
         )).collect(Collectors.toList());
 
         File report = new File(reportFolder, UUID.randomUUID() + ".csv");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/util/XeroxReportWriter.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/util/XeroxReportWriter.java
@@ -23,10 +23,10 @@ public final class XeroxReportWriter {
         );
 
         // Prepare a record for each of our letters.
-        List<List<String>> records = letterIds.map(x -> Lists.newArrayList(
+        List<List<String>> records = letterIds.map(id -> Lists.newArrayList(
             "01-01-2018",
             "10:30",
-            FileNameHelper.generatePdfName("aType", "aService", x, "pdf")
+            FileNameHelper.generatePdfName("aType", "aService", id)
         )).collect(Collectors.toList());
 
         File report = new File(reportFolder, UUID.randomUUID() + ".csv");

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -93,7 +93,7 @@ public class LetterService {
 
         byte[] zipContent = zipper.zip(
             new PdfDoc(
-                FileNameHelper.generateName(letter.getType(), serviceName, id, "pdf"),
+                FileNameHelper.generatePdfName(letter.getType(), serviceName, id, "pdf"),
                 getPdfContent(letter)
             )
         );

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -93,7 +93,7 @@ public class LetterService {
 
         byte[] zipContent = zipper.zip(
             new PdfDoc(
-                FileNameHelper.generatePdfName(letter.getType(), serviceName, id, "pdf"),
+                FileNameHelper.generatePdfName(letter.getType(), serviceName, id),
                 getPdfContent(letter)
             )
         );

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportParser.java
@@ -61,7 +61,7 @@ public class ReportParser {
     private LetterPrintStatus toPrintStatus(CSVRecord record) {
         try {
             return new LetterPrintStatus(
-                FileNameHelper.extractId(record.get("InputFileName")),
+                FileNameHelper.extractIdFromPdfName(record.get("InputFileName")),
                 ZonedDateTime.parse(record.get("StartDate") + "T" + record.get("StartTime") + "Z",
                     DateTimeFormatter.ofPattern("dd-MM-yyyy'T'HH:mm'Z'").withZone(ZoneOffset.UTC))
             );

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
@@ -10,16 +10,16 @@ public final class FileNameHelper {
 
     private static final String SEPARATOR = "_";
 
-    public static String generateName(Letter letter, String extension) {
-        return generateName(letter.getType(), letter.getService(), letter.getId(), extension);
+    public static String generatePdfName(Letter letter) {
+        return generatePdfName(letter.getType(), letter.getService(), letter.getId());
     }
 
-    public static String generateName(String type, String serviceName, UUID id, String extension) {
+    public static String generatePdfName(String type, String serviceName, UUID id) {
         String strippedService = serviceName.replace(SEPARATOR, "");
-        return type + SEPARATOR + strippedService + SEPARATOR + id + "." + extension;
+        return type + SEPARATOR + strippedService + SEPARATOR + id + ".pdf";
     }
 
-    public static UUID extractId(String fileName) {
+    public static UUID extractIdFromPdfName(String fileName) {
         String[] parts = FilenameUtils.removeExtension(fileName).split(SEPARATOR);
         if (parts.length < 3) {
             throw new UnableToExtractIdFromFileNameException("Invalid filename " + fileName);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/FileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/FileNameHelperTest.java
@@ -22,7 +22,7 @@ public class FileNameHelperTest {
         Letter letter = createLetter(letterId, "typeA", "cmc");
 
         // when
-        String result = FileNameHelper.generateName(letter, "pdf");
+        String result = FileNameHelper.generatePdfName(letter);
 
         // then
         assertThat(result).isEqualTo("typeA_cmc_" + letterId + ".pdf");
@@ -35,8 +35,8 @@ public class FileNameHelperTest {
         Letter letter1 = createLetter(letterId, "A", "B");
         Letter letter2 = createLetter(letterId, "A", "B");
 
-        String result1 = FileNameHelper.generateName(letter1, "pdf");
-        String result2 = FileNameHelper.generateName(letter2, "pdf");
+        String result1 = FileNameHelper.generatePdfName(letter1);
+        String result2 = FileNameHelper.generatePdfName(letter2);
 
         // then
         assertThat(result1).isEqualTo(result2);
@@ -48,8 +48,8 @@ public class FileNameHelperTest {
         Letter letter1 = createLetter(UUID.randomUUID(), "A", "B");
         Letter letter2 = createLetter(UUID.randomUUID(), "C", "D");
 
-        String result1 = FileNameHelper.generateName(letter1, "pdf");
-        String result2 = FileNameHelper.generateName(letter2, "pdf");
+        String result1 = FileNameHelper.generatePdfName(letter1);
+        String result2 = FileNameHelper.generatePdfName(letter2);
 
         // then
         assertThat(result1).isNotEqualTo(result2);
@@ -61,8 +61,8 @@ public class FileNameHelperTest {
         Letter letter1 = createLetter(UUID.randomUUID(), "A", "B");
         Letter letter2 = createLetter(UUID.randomUUID(), "A", "B");
 
-        String result1 = FileNameHelper.generateName(letter1, "pdf");
-        String result2 = FileNameHelper.generateName(letter2, "pdf");
+        String result1 = FileNameHelper.generatePdfName(letter1);
+        String result2 = FileNameHelper.generatePdfName(letter2);
 
         // then
         assertThat(result1).isNotEqualTo(result2);
@@ -73,7 +73,7 @@ public class FileNameHelperTest {
         UUID letterId = UUID.randomUUID();
         Letter letter = createLetter(letterId, "typeA", "cmc_claim_store");
 
-        String result = FileNameHelper.generateName(letter, "pdf");
+        String result = FileNameHelper.generatePdfName(letter);
 
         assertThat(result).isEqualTo("typeA_cmcclaimstore_" + letterId + ".pdf");
     }
@@ -86,8 +86,8 @@ public class FileNameHelperTest {
             createLetter(UUID.randomUUID(), "type", "my_service_"),
             createLetter(UUID.randomUUID(), "some_type", "my_service")
         ).forEach(letter -> {
-            String name = FileNameHelper.generateName(letter, "pdf");
-            UUID extractedId = FileNameHelper.extractId(name);
+            String name = FileNameHelper.generatePdfName(letter);
+            UUID extractedId = FileNameHelper.extractIdFromPdfName(name);
 
             assertThat(extractedId).isEqualTo(letter.getId());
         });
@@ -96,14 +96,14 @@ public class FileNameHelperTest {
     @Test
     public void should_throw_custom_exception_when_id_cannot_be_extracted_from_file_name() {
         assertThatThrownBy(
-            () -> FileNameHelper.extractId("a_b.pdf")
+            () -> FileNameHelper.extractIdFromPdfName("a_b.pdf")
         ).isInstanceOf(UnableToExtractIdFromFileNameException.class);
     }
 
     @Test
     public void should_throw_custom_exception_when_uuid_invalid() {
         assertThatThrownBy(
-            () -> FileNameHelper.extractId("a_b_notauuid.pdf")
+            () -> FileNameHelper.extractIdFromPdfName("a_b_notauuid.pdf")
         ).isInstanceOf(UnableToExtractIdFromFileNameException.class);
     }
 


### PR DESCRIPTION
In preparation for naming encrypted files...

Refactored method was always used to generate PDF, format for zip/pgp is different