### PR TITLE
Close hibernate repository streams

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
@@ -12,6 +13,7 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.stream.Stream;
 
 /**
  * Task to run report on unprinted letters and report them to AppInsights.
@@ -44,10 +46,9 @@ public class StaleLettersTask {
 
         logger.info("Started stale letter report job with cut-off of {}", staleCutOff);
 
-        long staleLetters = repo.findByStatusAndSentToPrintAtBefore(LetterStatus.Uploaded, staleCutOff)
-            .peek(insights::trackStaleLetter)
-            .count();
-
-        logger.info("Completed stale letter report job. Letters found: {}", staleLetters);
+        try (Stream<Letter> letters = repo.findByStatusAndSentToPrintAtBefore(LetterStatus.Uploaded, staleCutOff)) {
+            long count = letters.peek(insights::trackStaleLetter).count();
+            logger.info("Completed stale letter report job. Letters found: {}", count);
+        }
     }
 }


### PR DESCRIPTION
### Change description ###

[Streamed entities should be closed when using hibernate](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-streaming)

This change closes streams when loading Letters in Upload and stale letter tasks.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
