### PR TITLE
Updated vault env section to test

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -24,7 +24,7 @@ variable "env" {
 variable "vault_section" {
   type = "string"
   description = "Name of the environment-specific section in Vault key path, i.e. secret/{vault_section}/..."
-  default = "dev"
+  default = "test"
 }
 
 variable "ilbIp" {}


### PR DESCRIPTION
### Change description ###

- Encryption keys were not found in path `secret/dev/cc/send-letter/encryption-key`and sandbox deployment was failing as the key don't exist in that path.

- As per latest VNET pairing we will need sandbox to point to test instead of Dev.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```