### PR TITLE
Fixed s2s url and removed duplicate vault keys config

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -63,7 +63,7 @@ module "send-letter-service" {
   subscription        = "${var.subscription}"
 
   app_settings = {
-    S2S_URL                         = "${var.s2s_url}"
+    S2S_URL                         = "${local.s2s_url}"
     LETTER_TRACKING_DB_HOST         = "${module.db.host_name}"
     LETTER_TRACKING_DB_PORT         = "${module.db.postgresql_listen_port}"
     LETTER_TRACKING_DB_USER_NAME    = "${module.db.user_name}"
@@ -129,26 +129,6 @@ resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
 resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
   name      = "${var.component}-POSTGRES-DATABASE"
   value     = "${module.db.postgresql_database}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-# endregion
-
-# region smoke test config
-resource "azurerm_key_vault_secret" "test-s2s-url" {
-  name      = "test-s2s-url"
-  value     = "${var.s2s_url}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
-resource "azurerm_key_vault_secret" "test-s2s-name" {
-  name      = "test-s2s-name"
-  value     = "send_letter_tests"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
-resource "azurerm_key_vault_secret" "test-s2s-secret" {
-  name      = "test-s2s-secret"
-  value     = "${data.vault_generic_secret.tests_s2s_secret.data["value"]}"
   vault_uri = "${module.key-vault.key_vault_uri}"
 }
 # endregion

--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -1,6 +1,6 @@
 
 resource "azurerm_key_vault_secret" "test-s2s-url" {
-  name      = "s2s-url-for-tests"
+  name      = "test-s2s-url"
   value     = "${local.s2s_url}"
   vault_uri = "${module.key-vault.key_vault_uri}"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -42,10 +42,6 @@ variable "jenkins_AAD_objectId" {
   description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
 
-variable s2s_url {
-  default = "http://betadevbccidams2slb.reform.hmcts.net:80"
-}
-
 variable encyption_enabled {
   default = "false"
 }


### PR DESCRIPTION
### Change description ###

- Updated config to point to CNP s2s.

- Removed duplicate config.

- Successfully deployed on sandbox https://sandbox-build.platform.hmcts.net/job/HMCTS/job/send-letter-service/job/FIX-MULTIPLE-RESOURCE-VAULT-KEYS/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```