### PR TITLE
Stop SerialTaskRunner masking task exceptions

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunner.java
@@ -52,10 +52,16 @@ public final class SerialTaskRunner {
                 }
             } finally {
                 if (locked) {
-                    if (unlock(id, connection)) {
-                        log.info("Released lock {}", name);
-                    } else {
-                        log.warn("Failed to release lock {}", name);
+                    try {
+                        if (unlock(id, connection)) {
+                            log.info("Released lock {}", name);
+                        } else {
+                            log.warn("Failed to release lock {}", name);
+                        }
+                    } catch (SQLException s) {
+                        // Avoid throwing an Exception from this block
+                        // since it will mask any Exception thrown by the task.
+                        log.error("Exception unlocking task {}", name, s);
                     }
                 }
             }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunnerLockingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunnerLockingTest.java
@@ -99,7 +99,7 @@ public class SerialTaskRunnerLockingTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void runs_task_when_unlocking_throws_exception() throws SQLException {
+    public void does_not_throw_sql_exception_when_unlocking_throws_exception() throws SQLException {
         setupSuccessfulLocking();
         when(statement.executeQuery(startsWith("SELECT pg_advisory_unlock"))).thenThrow(SQLException.class);
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunnerLockingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunnerLockingTest.java
@@ -103,9 +103,8 @@ public class SerialTaskRunnerLockingTest {
         setupSuccessfulLocking();
         when(statement.executeQuery(startsWith("SELECT pg_advisory_unlock"))).thenThrow(SQLException.class);
 
-        Throwable exception = catchThrowable(() -> taskRunner.tryRun(MarkLettersPosted, task));
-
-        assertThat(exception).isInstanceOf(TaskRunnerException.class);
+        // Should not throw a SQLException.
+        taskRunner.tryRun(MarkLettersPosted, task);
         verify(task, only()).run();
     }
 


### PR DESCRIPTION
### Change description ###

Catch SQLExceptions thrown when the SerialTaskRunner unlocks the database lock, since they mask any exceptions thrown by the task.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
