### PR TITLE
Increase idle DB connection timeout to 2 hours

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,8 @@ spring:
         test-while-idle: true
         test-on-return: true
         remove-abandoned: true
-        remove-abandoned-timeout: 60
+        # Allow connections 2 hours idle before timing out.
+        remove-abandoned-timeout: 7200
         log-abandoned: true
         abandon-when-percentage-full: 0
 


### PR DESCRIPTION
### Change description ###
I discovered that the connections used to acquire our database locks are being timed out after 60 seconds and closed because they are idle - no queries are run on them while the lock is held.

When the connection is closed the locks are released and another task can run concurrently :(

This change is a mitigation rather than a fix; it works as long as hour tasks take less than 2 hours (which is true for the foreseeable).

In hindsight I was wrong to implement a custom locking solution and should have used an off the shelf job framework, which should probably be the long term plan.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
