### PR TITLE
Bug - delay background jobs in e2e tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/config/SftpConfig.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/config/SftpConfig.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.sendletter.config;
 import net.schmizz.sshj.SSHClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.sendletter.helper.FakeFtpAvailabilityChecker;
+import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
 import java.util.function.Supplier;
 
@@ -18,5 +20,10 @@ public class SftpConfig {
             client.addHostKeyVerifier((a, b, c) -> true);
             return client;
         };
+    }
+
+    @Bean()
+    public IFtpAvailabilityChecker ftpAvailabilityChecker() {
+        return new FakeFtpAvailabilityChecker();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.sendletter.config.ThreadPoolConfig;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
+import uk.gov.hmcts.reform.sendletter.helper.FakeFtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
 import uk.gov.hmcts.reform.sendletter.services.encryption.PgpDecryptionHelper;
 import uk.gov.hmcts.reform.sendletter.services.util.FileNameHelper;
@@ -48,6 +49,9 @@ public class BaseTest {
     @Autowired
     private LetterRepository repository;
 
+    @Autowired
+    private FakeFtpAvailabilityChecker fakeFtpAvailabilityChecker;
+
     @After
     public void cleanUp() {
         // This test commits transactions to the database
@@ -60,6 +64,10 @@ public class BaseTest {
         Boolean isEncryptionEnabled
     ) throws Throwable {
         try (LocalSftpServer server = LocalSftpServer.create()) {
+
+            // sftp servers is up, now the background jobs can start connecting to it
+            fakeFtpAvailabilityChecker.setAvailable(true);
+
             mvc.perform(request)
                 .andExpect(status().isOk())
                 .andReturn();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/helper/FakeFtpAvailabilityChecker.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/helper/FakeFtpAvailabilityChecker.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.sendletter.helper;
+
+import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
+
+import java.time.LocalTime;
+
+public class FakeFtpAvailabilityChecker implements IFtpAvailabilityChecker {
+
+    private boolean isAvailable = false;
+
+    @Override
+    public boolean isFtpAvailable(LocalTime time) {
+        return this.isAvailable;
+    }
+
+    @Override
+    public LocalTime getDowntimeStart() {
+        return LocalTime.now();
+    }
+
+    public void setAvailable(boolean value) {
+        isAvailable = value;
+    }
+}

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -43,8 +43,8 @@ scheduling.enabled: false
 tasks:
   upload-letters-interval-ms: ${UPLOAD_LETTERS_INTERVAL:1000}
   # Run every second.
-  mark-letters-posted: ${FTP_REPORTS_CRON:*/5 * * * * *}
-  stale-letters-report: ${FTP_REPORTS_CRON:*/5 * * * * *}
+  mark-letters-posted: ${FTP_REPORTS_CRON:*/1 * * * * *}
+  stale-letters-report: ${FTP_REPORTS_CRON:*/1 * * * * *}
 
 encryption:
   enabled: ${ENCRYPTION_ENABLED:false}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpAvailabilityChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpAvailabilityChecker.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalTime;
 
 @Component
-public class FtpAvailabilityChecker {
+public class FtpAvailabilityChecker implements IFtpAvailabilityChecker {
 
     private final LocalTime downtimeStart;
     private final LocalTime downtimeEnd;

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/IFtpAvailabilityChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/IFtpAvailabilityChecker.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.sendletter.services.ftp;
+
+import java.time.LocalTime;
+
+public interface IFtpAvailabilityChecker {
+    boolean isFtpAvailable(LocalTime time);
+    LocalTime getDowntimeStart();
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
@@ -9,8 +9,8 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.LetterPrintStatus;
 import uk.gov.hmcts.reform.sendletter.services.ReportParser;
-import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
+import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
 import java.sql.Timestamp;
 import java.time.LocalTime;
@@ -26,7 +26,7 @@ import static uk.gov.hmcts.reform.sendletter.tasks.Task.MarkLettersPosted;
 public class MarkLettersPostedTask {
     private final LetterRepository repo;
     private final FtpClient ftpClient;
-    private final FtpAvailabilityChecker ftpAvailabilityChecker;
+    private final IFtpAvailabilityChecker ftpAvailabilityChecker;
     private final ReportParser parser;
     private final AppInsights insights;
 
@@ -34,7 +34,7 @@ public class MarkLettersPostedTask {
 
     public MarkLettersPostedTask(LetterRepository repo,
                                  FtpClient ftp,
-                                 FtpAvailabilityChecker checker,
+                                 IFtpAvailabilityChecker checker,
                                  ReportParser parser,
                                  AppInsights insights) {
         this.repo = repo;

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
+import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -31,7 +32,7 @@ public class StaleLettersTask {
     public StaleLettersTask(
         LetterRepository repo,
         AppInsights insights,
-        FtpAvailabilityChecker checker
+        IFtpAvailabilityChecker checker
     ) {
         this.repo = repo;
         this.insights = insights;

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -8,8 +8,8 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
-import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
+import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.util.FinalPackageFileNameHelper;
 
 import java.sql.Timestamp;
@@ -27,13 +27,13 @@ public class UploadLettersTask {
 
     private final LetterRepository repo;
     private final FtpClient ftp;
-    private final FtpAvailabilityChecker availabilityChecker;
+    private final IFtpAvailabilityChecker availabilityChecker;
     private final AppInsights insights;
 
     public UploadLettersTask(
         LetterRepository repo,
         FtpClient ftp,
-        FtpAvailabilityChecker availabilityChecker,
+        IFtpAvailabilityChecker availabilityChecker,
         AppInsights insights
     ) {
         this.repo = repo;


### PR DESCRIPTION
In some cases (quite often on travis) the jobs in e2e test would start before in-memory sftp server was up, thus causing exception which made the tests fail.

This PR introduces `FakeFtpAvailabilityChecker` class (used only in tests) which can be used to control the FTP 'downtime window' and prevent jobs from trying to make a connection to in-memory sftp server.
