### PR TITLE
Updated type for zip/pgp file name for functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
@@ -31,8 +31,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @TestPropertySource("classpath:application.properties")
 public abstract class FunctionalTestSuite {
 
-    protected static final String SMOKE_TEST_LETTER_TYPE = "smoke_test";
-
     @Value("${s2s-url}")
     protected String s2sUrl;
 
@@ -161,7 +159,7 @@ public abstract class FunctionalTestSuite {
     protected String getPdfFileNamePattern(String letterId) {
         return String.format(
             "%s_%s_%s.pdf",
-            Pattern.quote(SMOKE_TEST_LETTER_TYPE),
+            Pattern.quote("smoke_test"),
             Pattern.quote(s2sName.replace("_", "")),
             Pattern.quote(letterId)
         );
@@ -172,7 +170,7 @@ public abstract class FunctionalTestSuite {
 
         return String.format(
             format,
-            Pattern.quote(SMOKE_TEST_LETTER_TYPE),
+            Pattern.quote("smoketest"),
             Pattern.quote(s2sName.replace("_", "")),
             Pattern.quote(letterId)
         );


### PR DESCRIPTION
### Change description ###

- File name pattern generation logic has changed but functional tests were not updated.This PR updates that.

- PDF file name generation is unchanged so no changes for that.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```