### PR TITLE
Added vault name and vault uri

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -50,7 +50,7 @@ locals {
   vaultName              = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
 
   nonPreviewVaultUri     = "${module.send-letter-key-vault.key_vault_uri}"
-  previewVaultUri        = "https://send-letter-service-aat.vault.azure.net/"
+  previewVaultUri        = "https://rpe-send-letter-aat.vault.azure.net/"
   vaultUri               = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultUri : local.nonPreviewVaultUri}"
 
   db_connection_options  = "?ssl=true"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -33,13 +33,26 @@ data "vault_generic_secret" "encryption_public_key" {
 
 locals {
   ase_name               = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+
   ftp_private_key        = "${replace(data.vault_generic_secret.ftp_private_key.data["value"], "\\n", "\n")}"
   ftp_public_key         = "${replace(data.vault_generic_secret.ftp_public_key.data["value"], "\\n", "\n")}"
   ftp_user               = "${data.vault_generic_secret.ftp_user.data["value"]}"
+
   encryption_public_key  = "${replace(data.vault_generic_secret.encryption_public_key.data["value"], "\\n", "\n")}"
+
   local_env              = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
   local_ase              = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "core-compute-aat" : "core-compute-saat" : local.ase_name}"
+
   s2s_url                = "http://rpe-service-auth-provider-${local.local_env}.service.${local.local_ase}.internal"
+
+  previewVaultName       = "${var.product}-send-letter"
+  nonPreviewVaultName    = "${var.product}-send-letter-${var.env}"
+  vaultName              = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
+
+  nonPreviewVaultUri     = "${module.send-letter-key-vault.key_vault_uri}"
+  previewVaultUri        = "https://send-letter-service-aat.vault.azure.net/"
+  vaultUri               = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultUri : local.nonPreviewVaultUri}"
+
   db_connection_options  = "?ssl=true"
 }
 
@@ -90,8 +103,9 @@ module "send-letter-service" {
 }
 
 # region save DB details to Azure Key Vault
-module "key-vault" {
+module "send-letter-key-vault" {
   source              = "git@github.com:hmcts/moj-module-key-vault?ref=master"
+  name                = "${local.vaultName}"
   product             = "${var.product}"
   env                 = "${var.env}"
   tenant_id           = "${var.tenant_id}"
@@ -104,30 +118,30 @@ module "key-vault" {
 resource "azurerm_key_vault_secret" "POSTGRES-USER" {
   name      = "${var.component}-POSTGRES-USER"
   value     = "${module.db.user_name}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES-PASS" {
   name      = "${var.component}-POSTGRES-PASS"
   value     = "${module.db.postgresql_password}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
   name      = "${var.component}-POSTGRES-HOST"
   value     = "${module.db.host_name}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
   name      = "${var.component}-POSTGRES-PORT"
   value     = "${module.db.postgresql_listen_port}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
   name      = "${var.component}-POSTGRES-DATABASE"
   value     = "${module.db.postgresql_database}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 # endregion

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,8 +49,6 @@ locals {
   nonPreviewVaultName    = "${var.product}-send-letter-${var.env}"
   vaultName              = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
 
-  vaultUri               = "${module.send-letter-key-vault.key_vault_uri}"
-
   db_connection_options  = "?ssl=true"
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,9 +49,7 @@ locals {
   nonPreviewVaultName    = "${var.product}-send-letter-${var.env}"
   vaultName              = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
 
-  nonPreviewVaultUri     = "${module.send-letter-key-vault.key_vault_uri}"
-  previewVaultUri        = "https://rpe-send-letter-aat.vault.azure.net/"
-  vaultUri               = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultUri : local.nonPreviewVaultUri}"
+  vaultUri               = "${module.send-letter-key-vault.key_vault_uri}"
 
   db_connection_options  = "?ssl=true"
 }

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,9 +1,9 @@
 output "vaultUri" {
-  value = "${module.key-vault.key_vault_uri}"
+  value = "${local.vaultUri}"
 }
 
 output "vaultName" {
-  value = "${module.key-vault.key_vault_name}"
+  value = "${local.vaultName}"
 }
 
 output "microserviceName" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,5 +1,5 @@
 output "vaultUri" {
-  value = "${local.vaultUri}"
+  value = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 output "vaultName" {

--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -2,65 +2,65 @@
 resource "azurerm_key_vault_secret" "test-s2s-url" {
   name      = "test-s2s-url"
   value     = "${local.s2s_url}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-s2s-name" {
   name      = "test-s2s-name"
   value     = "send_letter_tests"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-s2s-secret" {
   name      = "test-s2s-secret"
   value     = "${data.vault_generic_secret.tests_s2s_secret.data["value"]}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-hostname" {
   name      = "test-ftp-hostname"
   value     = "${var.ftp_hostname}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-port" {
   name      = "test-ftp-port"
   value     = "${var.ftp_port}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-fingerprint" {
   name      = "test-ftp-fingerprint"
   value     = "${var.ftp_fingerprint}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-target-folder" {
   name      = "test-ftp-target-folder"
   value     = "${var.ftp_smoke_test_target_folder}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-user" {
   name      = "test-ftp-user"
   value     = "${local.ftp_user}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-private-key" {
   name      = "test-ftp-private-key"
   value     = "${local.ftp_private_key}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-ftp-public-key" {
   name      = "test-ftp-public-key"
   value     = "${local.ftp_public_key}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-encryption-enabled" {
   name      = "test-encryption-enabled"
   value     = "${var.encyption_enabled}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }


### PR DESCRIPTION
### Change description ###

- As we have not specified the vault name in our module default naming convention is <product>-<env>.

- As we have s2s in prod and aat and that one use default vault name we get a conflict 409  as `rpe-aat` and `rpe-prod`  already exists in those environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```