### PR TITLE
Upgrade SSHD test SFTP server to 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ dependencies {
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
   testCompile group: 'com.google.guava', name: 'guava', version: '23.4-jre'
-  testCompile group: 'org.apache.sshd', name: 'sshd-sftp', version: '0.9.0'
+  testCompile group: 'org.apache.sshd', name: 'sshd-core', version: '1.7.0'
   testCompile group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'
   testCompile group: 'org.apache.pdfbox', name: 'preflight', version: '2.0.8'
 


### PR DESCRIPTION
### Change description ###
This fixes the intermittent test failure 'KeyExchange signature verification failed', which I believe is due to a bug in the really old version of sshd-sftp we were using, instead of the up to date sftp
server in sshd-core.

To investigate this I set up a test loop where our FtpClient continually connected and disconnected to a local sshd server.

With the old version of sshd-sftp I would get a KeyExchange exception after a few seconds to a couple of minutes. After upgrading to sshd-core 1.7.0 I was able to run the loop for an hour without any
 problems.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
