### PR TITLE
Move PostgreSQL database from West Europe to UK South

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -54,7 +54,7 @@ locals {
 
 module "db" {
   source              = "git@github.com:hmcts/moj-module-postgres?ref=cnp-449-tactical"
-  product             = "${var.product}-postgres-db"
+  product             = "${var.product}-${var.component}-db"
   location            = "${var.location_db}"
   env                 = "${var.env}"
   database_name       = "send_letter"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -54,11 +54,11 @@ locals {
 
 module "db" {
   source              = "git@github.com:hmcts/moj-module-postgres?ref=cnp-449-tactical"
-  product             = "${var.product}-db"
+  product             = "${var.product}-postgres-db"
   location            = "${var.location_db}"
   env                 = "${var.env}"
-  postgresql_database = "postgres"
-  postgresql_user     = "letter_tracking"
+  database_name       = "send_letter"
+  postgresql_user     = "send_letter"
   sku_name            = "GP_Gen5_2"
   sku_tier            = "GeneralPurpose"
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -53,12 +53,14 @@ locals {
 }
 
 module "db" {
-  source              = "git@github.com:hmcts/moj-module-postgres.git?ref=master"
+  source              = "git@github.com:hmcts/moj-module-postgres?ref=cnp-449-tactical"
   product             = "${var.product}-db"
   location            = "${var.location_db}"
   env                 = "${var.env}"
   postgresql_database = "postgres"
   postgresql_user     = "letter_tracking"
+  sku_name            = "GP_Gen5_2"
+  sku_tier            = "GeneralPurpose"
 }
 
 module "send-letter-service" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -13,7 +13,7 @@ variable "location_app" {
 
 variable "location_db" {
   type    = "string"
-  default = "West Europe"
+  default = "UK South"
 }
 
 variable "env" {


### PR DESCRIPTION
### Change description ###

Move PostgreSQL database from West Europe to UK South. Also, because the new version of moj-module-postgres allows for it, rename the DB (to something different than `postgres`) and user.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
