### PR TITLE
Simplify pgp util exceptions

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -60,7 +60,7 @@ public class LetterService {
         this.mapper = mapper;
         this.isEncryptionEnabled = isEncryptionEnabled;
         this.encryptionPublicKey = encryptionPublicKey;
-        this.pgpPublicKey = loadPgpPudblicKey(encryptionPublicKey);
+        this.pgpPublicKey = loadPgpPublicKey(encryptionPublicKey);
     }
 
     @Transactional
@@ -132,7 +132,7 @@ public class LetterService {
         return PgpEncryptionUtil.encryptFile(zipContent, zipFileName, pgpPublicKey, true);
     }
 
-    private PGPPublicKey loadPgpPudblicKey(String encryptionPublicKey) {
+    private PGPPublicKey loadPgpPublicKey(String encryptionPublicKey) {
         if (!isEncryptionEnabled) {
             log.info("Encryption is not enabled hence not loading the public key");
             return null;

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sendletter.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.util.Asserts;
-import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,14 +18,11 @@ import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.in.LetterWithPdfsRequest;
 import uk.gov.hmcts.reform.sendletter.model.out.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.services.encryption.PgpEncryptionUtil;
-import uk.gov.hmcts.reform.sendletter.services.encryption.UnableToLoadPgpPublicKeyException;
-import uk.gov.hmcts.reform.sendletter.services.encryption.UnableToPgpEncryptZipFileException;
 import uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator;
 import uk.gov.hmcts.reform.sendletter.services.util.FileNameHelper;
 import uk.gov.hmcts.reform.sendletter.services.util.FinalPackageFileNameHelper;
 import uk.gov.hmcts.reform.sendletter.services.zip.Zipper;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -64,7 +60,7 @@ public class LetterService {
         this.mapper = mapper;
         this.isEncryptionEnabled = isEncryptionEnabled;
         this.encryptionPublicKey = encryptionPublicKey;
-        this.pgpPublicKey = loadPgpPublicKey(encryptionPublicKey);
+        this.pgpPublicKey = loadPgpPudblicKey(encryptionPublicKey);
     }
 
     @Transactional
@@ -133,41 +129,16 @@ public class LetterService {
             true
         );
 
-        try {
-            return PgpEncryptionUtil.encryptFile(zipContent, zipFileName, pgpPublicKey, true);
-
-        } catch (IOException ioException) {
-            log.error(
-                "Error occurred while loading public key encryption",
-                ioException
-            );
-            throw new UnableToLoadPgpPublicKeyException("PGP Public key object could not be constructed", ioException);
-        } catch (PGPException pgpException) {
-            log.error(
-                String.format("Error occurred during encrypting zip file: %s", zipFileName),
-                pgpException
-            );
-
-            throw new UnableToPgpEncryptZipFileException(pgpException);
-        }
+        return PgpEncryptionUtil.encryptFile(zipContent, zipFileName, pgpPublicKey, true);
     }
 
-    private PGPPublicKey loadPgpPublicKey(String encryptionPublicKey) {
+    private PGPPublicKey loadPgpPudblicKey(String encryptionPublicKey) {
         if (!isEncryptionEnabled) {
             log.info("Encryption is not enabled hence not loading the public key");
             return null;
-        }
-
-        Asserts.notNull(encryptionPublicKey, "encryptionPublicKey");
-
-        try {
+        } else {
+            Asserts.notNull(encryptionPublicKey, "encryptionPublicKey");
             return PgpEncryptionUtil.loadPublicKey(encryptionPublicKey.getBytes());
-        } catch (IOException ioException) {
-            log.error(
-                "Error occurred while loading public key encryption",
-                ioException
-            );
-            throw new UnableToLoadPgpPublicKeyException("PGP Public key object could not be constructed", ioException);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/encryption/UnableToLoadPgpPublicKeyException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/encryption/UnableToLoadPgpPublicKeyException.java
@@ -11,11 +11,7 @@ public class UnableToLoadPgpPublicKeyException extends UnknownErrorCodeException
 
     private static final long serialVersionUID = -5621910255408117685L;
 
-    public UnableToLoadPgpPublicKeyException(String message) {
-        super(AlertLevel.P1, message);
-    }
-
-    public UnableToLoadPgpPublicKeyException(String message, Throwable cause) {
-        super(AlertLevel.P1, message, cause);
+    public UnableToLoadPgpPublicKeyException(Throwable cause) {
+        super(AlertLevel.P1, cause);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
@@ -112,8 +112,7 @@ public class LetterServiceTest {
     @Test
     public void should_throw_unable_to_load_pgp_pub_key_exc_on_init_when_enc_enabled_and_invalid_pub_key_is_passed() {
         assertThatThrownBy(() -> createLetterService(true, "This is not a proper pgp public key"))
-            .isInstanceOf(UnableToLoadPgpPublicKeyException.class)
-            .hasMessage("PGP Public key object could not be constructed");
+            .isInstanceOf(UnableToLoadPgpPublicKeyException.class);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpEncryptionUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpEncryptionUtilTest.java
@@ -74,13 +74,13 @@ public class PgpEncryptionUtilTest {
     }
 
     @Test
-    public void should_throw_io_exception_when_invalid_pubic_key_is_passed() {
+    public void should_throw_custom_exception_when_invalid_pubic_key_is_passed() {
         Throwable exc = Assertions.catchThrowable(
             () -> PgpEncryptionUtil.loadPublicKey("this is not public key".getBytes())
         );
 
         assertThat(exc)
-            .isInstanceOf(IOException.class);
+            .isInstanceOf(UnableToLoadPgpPublicKeyException.class);
     }
 
     private byte[] loadPublicKey() throws IOException {


### PR DESCRIPTION
Throw runtime exceptions defined in the encryption module from the util class instead of forcing the clients to handle ambiguous `IOException` and bouncycastle's exception.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
