### PR TITLE
Remove default product name from terraform

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,6 +1,5 @@
 variable "product" {
   type    = "string"
-  default = "send-letter-2"
 }
 
 variable "component" {


### PR DESCRIPTION
### Change description ###

Remove default product name from terraform. Jenkins provides the name, based on what's in `Jekinsfile_...`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
