### PR TITLE
Fix product and component name in Jenkinsfile_parameterized

### DIFF
--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -26,8 +26,8 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 properties([
   parameters([
-    string(name: 'PRODUCT_NAME', defaultValue: 'send-letter', description: ''),
-    string(name: 'APP', defaultValue: 'service', description: ''),
+    string(name: 'PRODUCT_NAME', defaultValue: 'rpe', description: ''),
+    string(name: 'APP', defaultValue: 'send-letter-service', description: ''),
     string(name: 'TYPE', defaultValue: 'java', description: ''),
     string(name: 'ENVIRONMENT', defaultValue: 'sandbox', description: 'Environment where code should be build and deployed'),
     choice(name: 'SUBSCRIPTION', choices: 'sandbox', description: 'Azure subscriptions available to build in')


### PR DESCRIPTION
### Change description ###

Fix product and component name in Jenkinsfile_parameterized. Those names need to be the same as in Jenkinsfile_CNP.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
