### PR TITLE
Enable scheduling for spring boot 2

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/Application.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCircuitBreaker
 @EnableHystrixDashboard
+@EnableScheduling
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 


### PR DESCRIPTION
### Change description ###

Adds the EnableScheduling annotation to the Application class. I'm not sure why this was working for our v1 application! This fixes all the tests for me.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
