### PR TITLE
Fix encrypted file extension

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -132,13 +132,18 @@ public class BaseTest {
             if (isEncryptionEnabled) {
                 // Decrypt encrypted zip file so that we can confirm if we are able to decrypt the encrypted zip
                 // using private key and passphrase
-                content = PgpDecryptionHelper.decryptFile(
+                PgpDecryptionHelper.DecryptedFile decryptedFile = PgpDecryptionHelper.decryptFile(
                     content,
                     getClass().getResourceAsStream("/encryption/privatekey.asc"),
                     "Password1".toCharArray()
                 );
+
+                assertThat(decryptedFile.filename).endsWith(".zip");
+                PdfHelper.validateZippedPdf(decryptedFile.content);
+
+            } else {
+                PdfHelper.validateZippedPdf(content);
             }
-            PdfHelper.validateZippedPdf(content);
         } catch (IOException | PGPException e) {
             // File may still be being written to disk by FTP server.
             return false;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceWithEncryptionEnabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceWithEncryptionEnabledTest.java
@@ -66,13 +66,13 @@ public class LetterServiceWithEncryptionEnabledTest {
 
         byte[] encryptedZip = letterInDb.getFileContent();
 
-        byte[] decryptedZip = PgpDecryptionHelper.decryptFile(
+        PgpDecryptionHelper.DecryptedFile decryptedZip = PgpDecryptionHelper.decryptFile(
             encryptedZip,
             getClass().getResourceAsStream("/encryption/privatekey.asc"),
             "Password1".toCharArray()
         );
         //then
         //We don't have the original zip so just verifying if we could decrypt the encrypted file.
-        assertThat(decryptedZip).isNotEmpty();
+        assertThat(decryptedZip.content).isNotEmpty();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -126,7 +126,7 @@ public class LetterService {
             serviceName,
             createdAt,
             id,
-            true
+            false
         );
 
         return PgpEncryptionUtil.encryptFile(zipContent, zipFileName, pgpPublicKey, true);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpDecryptionHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpDecryptionHelper.java
@@ -33,7 +33,9 @@ public final class PgpDecryptionHelper {
      * decrypt the passed in message stream.
      */
     @SuppressWarnings("unchecked")
-    public static DecryptedFile decryptFile(byte[] in, InputStream keyIn, char... passwd) throws IOException, PGPException {
+    public static DecryptedFile decryptFile(byte[] in, InputStream keyIn, char... passwd)
+        throws IOException, PGPException
+    {
         Security.addProvider(new BouncyCastleProvider());
 
         PGPObjectFactory objectFactory = new PGPObjectFactory(in, new JcaKeyFingerprintCalculator());

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpDecryptionHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpDecryptionHelper.java
@@ -33,7 +33,7 @@ public final class PgpDecryptionHelper {
      * decrypt the passed in message stream.
      */
     @SuppressWarnings("unchecked")
-    public static byte[] decryptFile(byte[] in, InputStream keyIn, char... passwd) throws IOException, PGPException {
+    public static DecryptedFile decryptFile(byte[] in, InputStream keyIn, char... passwd) throws IOException, PGPException {
         Security.addProvider(new BouncyCastleProvider());
 
         PGPObjectFactory objectFactory = new PGPObjectFactory(in, new JcaKeyFingerprintCalculator());
@@ -93,17 +93,17 @@ public final class PgpDecryptionHelper {
             while ((ch = unc.read()) >= 0) {
                 byteArrayOutputStream.write(ch);
             }
+
+            if (pbe.isIntegrityProtected() && !pbe.verify()) {
+                throw new PGPException("Message failed integrity check");
+            }
+
+            return new DecryptedFile(ld.getFileName(), byteArrayOutputStream.toByteArray());
         } else if (message instanceof PGPOnePassSignatureList) {
             throw new PGPException("Encrypted message contains a signed message - not literal data.");
         } else {
             throw new PGPException("Message is not a simple encrypted file - type unknown.");
         }
-
-        if (pbe.isIntegrityProtected() && !pbe.verify()) {
-            throw new PGPException("Message failed integrity check");
-        }
-
-        return byteArrayOutputStream.toByteArray();
     }
 
     private static PGPPrivateKey findPrivateKey(InputStream keyIn, long keyId, char... pass)
@@ -127,5 +127,15 @@ public final class PgpDecryptionHelper {
                 new BcPGPDigestCalculatorProvider()
             ).build(pass);
         return pgpSecKey.extractPrivateKey(decryptor);
+    }
+
+    public static class DecryptedFile {
+        public final String filename;
+        public final byte[] content;
+
+        public DecryptedFile(String filename, byte[] content) {
+            this.filename = filename;
+            this.content = content;
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpEncryptionUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpEncryptionUtilTest.java
@@ -41,6 +41,7 @@ public class PgpEncryptionUtilTest {
 
         //then
         assertThat(inputZipFile).containsExactly(decryptedZip.content);
+        assertThat(decryptedZip.filename).isEqualTo(inputFileName);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpEncryptionUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/encryption/PgpEncryptionUtilTest.java
@@ -33,14 +33,14 @@ public class PgpEncryptionUtilTest {
 
         //We are decrypting it using BountyCastle to validate if the decrypted zip is same as input file.
         //Currently this seems to be the only way to validate the file contents.
-        byte[] decryptedZip = PgpDecryptionHelper.decryptFile(
+        PgpDecryptionHelper.DecryptedFile decryptedZip = PgpDecryptionHelper.decryptFile(
             pgpEncryptedZip,
             loadPrivateKey(),
             "Password1".toCharArray()
         );
 
         //then
-        assertThat(inputZipFile).containsExactly(decryptedZip);
+        assertThat(inputZipFile).containsExactly(decryptedZip.content);
     }
 
     @Test
@@ -63,14 +63,14 @@ public class PgpEncryptionUtilTest {
 
         //We are decrypting it using BountyCastle to validate if the decrypted zip is same as input file.
         //Currently this seems to be the only way to validate the file contents.
-        byte[] decryptedZip = PgpDecryptionHelper.decryptFile(
+        PgpDecryptionHelper.DecryptedFile decryptedZip = PgpDecryptionHelper.decryptFile(
             pgpEncryptedZip,
             loadPrivateKey(),
             "Password1".toCharArray()
         );
 
         //then
-        assertThat(inputZipFile).containsExactly(decryptedZip);
+        assertThat(inputZipFile).containsExactly(decryptedZip.content);
     }
 
     @Test


### PR DESCRIPTION
Before this change, the zip file inside the PGP archive had .pgp instead of .zip extension.