### PR TITLE
Temporarily changed path for encryption keys

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,7 +28,9 @@ data "vault_generic_secret" "ftp_public_key" {
 }
 
 data "vault_generic_secret" "encryption_public_key" {
-  path = "secret/${var.vault_section}/cc/send-letter/encryption-key"
+  # Changing the path temporarily so that terraform can refresh new value for prod.
+  #path = "secret/${var.vault_section}/cc/send-letter/encryption-key"
+  path = "secret/${var.vault_section}/cc/send-letter-consumer/ftp-public-key"
 }
 
 locals {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-375

### Change description ###

- Currently value of public encryption key is TBD which is now updated with proper pgp key.

- As terraform won't update the value without changing vault path (even if the value is changed in Hashicorp vault)we have to change the path first and next PR will change it back to what it was.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```