### PR TITLE
Fix void method reporting

### DIFF
--- a/lib/AI-Agent.xml
+++ b/lib/AI-Agent.xml
@@ -19,18 +19,18 @@
             <Method name="encryptFile"/>
         </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient">
-            <Method name="upload"/>
+            <Method name="upload" signature="(Lnet/schmizz/sshj/xfer/LocalSourceFile;Z)V"/>
             <Method name="downloadReports"/>
-            <Method name="deleteReport"/>
+            <Method name="deleteReport" signature="(Ljava/lang/String)V"/>
         </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator">
             <Method name="createFromTemplates"/>
             <Method name="createFromBase64Pdfs"/>
         </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.tasks.TaskSchedule">
-            <Method name="uploadLetters"/>
-            <Method name="markPosted"/>
-            <Method name="staleLetters"/>
+            <Method name="uploadLetters" signature="()V"/>
+            <Method name="markPosted" signature="()V"/>
+            <Method name="staleLetters" signature="()V"/>
         </Class>
     </Instrumentation>
 </ApplicationInsightsAgent>

--- a/lib/AI-Agent.xml
+++ b/lib/AI-Agent.xml
@@ -19,18 +19,18 @@
             <Method name="encryptFile"/>
         </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient">
-            <Method name="upload" signature="(Lnet/schmizz/sshj/xfer/LocalSourceFile;Z)V"/>
+            <Method name="upload" reportExecutionTime="true" signature="(Lnet/schmizz/sshj/xfer/LocalSourceFile;Z)V"/>
             <Method name="downloadReports"/>
-            <Method name="deleteReport" signature="(Ljava/lang/String)V"/>
+            <Method name="deleteReport" reportExecutionTime="true" signature="(Ljava/lang/String;)V"/>
         </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator">
             <Method name="createFromTemplates"/>
             <Method name="createFromBase64Pdfs"/>
         </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.tasks.TaskSchedule">
-            <Method name="uploadLetters" signature="()V"/>
-            <Method name="markPosted" signature="()V"/>
-            <Method name="staleLetters" signature="()V"/>
+            <Method name="uploadLetters" reportExecutionTime="true" signature="()V"/>
+            <Method name="markPosted" reportExecutionTime="true" signature="()V"/>
+            <Method name="staleLetters" reportExecutionTime="true" signature="()V"/>
         </Class>
     </Instrumentation>
 </ApplicationInsightsAgent>

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/SerialTaskRunner.java
@@ -36,23 +36,23 @@ public final class SerialTaskRunner {
      * supplied Runnable is simply not executed.
      */
     void tryRun(Task task, Runnable runnable) {
-        log.info("Trying to lock {}", task);
+        log.debug("Trying to lock {}", task);
 
         try (Connection connection = source.getConnection()) {
             boolean locked = false;
             try {
                 if (tryLock(task, connection)) {
-                    log.info("Acquired lock {}", task);
+                    log.debug("Acquired lock {}", task);
                     locked = true;
                     runnable.run();
                 } else {
-                    log.info("Failed to acquire lock {}", task);
+                    log.debug("Failed to acquire lock {}", task);
                 }
             } finally {
                 if (locked) {
                     try {
                         if (unlock(task, connection)) {
-                            log.info("Released lock {}", task);
+                            log.debug("Released lock {}", task);
                         } else {
                             log.warn("Failed to release lock {}", task);
                         }


### PR DESCRIPTION
Application Insights' Agent did not know how to track void methods. Need to specifically specify signature as mentioned in example [here](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/application-insights/app-insights-java-agent.md#configure-the-agent) and how-to [guide](http://www.rgagnon.com/javadetails/java-0286.html)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
