### PR TITLE
Fix FTP dependency tracking

### DIFF
--- a/lib/AI-Agent.xml
+++ b/lib/AI-Agent.xml
@@ -18,11 +18,6 @@
         <Class name="uk.gov.hmcts.reform.sendletter.services.encryption.PgpEncryptionUtil">
             <Method name="encryptFile"/>
         </Class>
-        <Class name="uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient">
-            <Method name="upload"/>
-            <Method name="downloadReports"/>
-            <Method name="deleteReport"/>
-        </Class>
         <Class name="uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator">
             <Method name="createFromTemplates"/>
             <Method name="createFromBase64Pdfs"/>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/helper/FtpHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/helper/FtpHelper.java
@@ -4,11 +4,14 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import net.schmizz.sshj.SSHClient;
 import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties;
+import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 
 import java.io.IOException;
 import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
 
 public final class FtpHelper {
 
@@ -25,7 +28,7 @@ public final class FtpHelper {
             client.addHostKeyVerifier((a, b, c) -> verified);
             return client;
         };
-        return new FtpClient(s, getFtpConfig(port));
+        return new FtpClient(s, getFtpConfig(port), mock(AppInsights.class));
     }
 
     public static FtpClient getFailingClient(int port) throws IOException {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependency.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependency.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.sendletter.logging;
+
+public final class AppDependency {
+
+    static final String FTP_CLIENT = "FtpClient";
+
+    private AppDependency() {
+        // utility class constructor
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependencyCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppDependencyCommand.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.sendletter.logging;
+
+final class AppDependencyCommand {
+
+    static final String FTP_FILE_UPLOADED = "FtpFileUploaded";
+
+    static final String FTP_REPORT_DELETED = "FtpReportDeleted";
+
+    static final String FTP_REPORT_DOWNLOADED = "FtpReportDownloaded";
+
+    private AppDependencyCommand() {
+        // utility class constructor
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sendletter.logging;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.core.dependencies.apachecommons.lang3.BooleanUtils;
+import com.microsoft.applicationinsights.telemetry.Duration;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.logging.appinsights.AbstractAppInsights;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
@@ -28,6 +29,24 @@ public class AppInsights extends AbstractAppInsights {
     public AppInsights(TelemetryClient telemetry) {
         super(telemetry);
 
+    }
+
+    // dependencies
+
+    private void trackDependency(String dependency, String command, java.time.Duration duration, boolean success) {
+        telemetry.trackDependency(dependency, command, new Duration(duration.toMillis()), success);
+    }
+
+    public void trackFtpUpload(java.time.Duration duration, boolean success) {
+        trackDependency(AppDependency.FTP_CLIENT, AppDependencyCommand.FTP_FILE_UPLOADED, duration, success);
+    }
+
+    public void trackFtpReportDeletion(java.time.Duration duration, boolean success) {
+        trackDependency(AppDependency.FTP_CLIENT, AppDependencyCommand.FTP_REPORT_DELETED, duration, success);
+    }
+
+    public void trackFtpReportDownload(java.time.Duration duration, boolean success) {
+        trackDependency(AppDependency.FTP_CLIENT, AppDependencyCommand.FTP_REPORT_DOWNLOADED, duration, success);
     }
 
     // events

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -53,7 +53,7 @@ public class FtpClient {
         Instant now = Instant.now();
 
         runWith(sftp -> {
-            boolean success = false;
+            boolean isSuccess = false;
 
             try {
                 String folder = isSmokeTestFile
@@ -63,13 +63,13 @@ public class FtpClient {
                 String path = String.join("/", folder, file.getName());
                 sftp.getFileTransfer().upload(file, path);
 
-                success = true;
+                isSuccess = true;
 
                 return null;
             } catch (IOException exc) {
                 throw new FtpException("Unable to upload file.", exc);
             } finally {
-                insights.trackFtpUpload(Duration.between(now, Instant.now()), success);
+                insights.trackFtpUpload(Duration.between(now, Instant.now()), isSuccess);
             }
         });
     }
@@ -81,7 +81,7 @@ public class FtpClient {
         Instant now = Instant.now();
 
         return runWith(sftp -> {
-            boolean success = false;
+            boolean isSuccess = false;
 
             try {
                 SFTPFileTransfer transfer = sftp.getFileTransfer();
@@ -100,13 +100,13 @@ public class FtpClient {
                     })
                     .collect(toList());
 
-                success = true;
+                isSuccess = true;
 
                 return reports;
             } catch (IOException exc) {
                 throw new FtpException("Error while downloading reports", exc);
             } finally {
-                insights.trackFtpReportDownload(Duration.between(now, Instant.now()), success);
+                insights.trackFtpReportDownload(Duration.between(now, Instant.now()), isSuccess);
             }
         });
     }
@@ -115,18 +115,18 @@ public class FtpClient {
         Instant now = Instant.now();
 
         runWith(sftp -> {
-            boolean success = false;
+            boolean isSuccess = false;
 
             try {
                 sftp.rm(reportPath);
 
-                success = true;
+                isSuccess = true;
 
                 return null;
             } catch (Exception exc) {
                 throw new FtpException("Error while deleting report: " + reportPath, exc);
             } finally {
-                insights.trackFtpReportDeletion(Duration.between(now, Instant.now()), success);
+                insights.trackFtpReportDeletion(Duration.between(now, Instant.now()), isSuccess);
             }
         });
     }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties;
 import uk.gov.hmcts.reform.sendletter.exception.FtpException;
+import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.Report;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
@@ -40,13 +41,14 @@ public class FtpClientTest {
     @Mock private SFTPClient sftpClient;
     @Mock private SFTPFileTransfer sftpFileTransfer;
     @Mock private FtpConfigProperties ftpProps;
+    @Mock private AppInsights insights;
 
     @Before
     public void setUp() throws Exception {
         given(sshClient.newSFTPClient()).willReturn(sftpClient);
         given(sftpClient.getFileTransfer()).willReturn(sftpFileTransfer);
 
-        client = new FtpClient(() -> sshClient, ftpProps);
+        client = new FtpClient(() -> sshClient, ftpProps, insights);
     }
 
     @Test


### PR DESCRIPTION
As inspected in production - there is no FTP tracking happening automagically for us. After attempts to apply signature as MS suggests no luck achieved. Going back to old way of just manually tracking the dependency to keep track of this activity

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
