### PR TITLE
Include additional data in logging as it includes claim number

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Letter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Letter.java
@@ -123,6 +123,10 @@ public class Letter {
         return isFailed;
     }
 
+    public void setAdditionalData(JsonNode additionalData) {
+        this.additionalData = additionalData;
+    }
+
     public JsonNode getAdditionalData() {
         return additionalData;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -79,10 +79,11 @@ public class UploadLettersTask {
         );
 
         logger.debug(
-            "Uploading letter id: {}, messageId: {}, file name: {}",
+            "Uploading letter id: {}, messageId: {}, file name: {}, additional data: {}",
             letter.getId(),
             letter.getMessageId(),
-            file.filename
+            file.filename,
+            letter.getAdditionalData()
         );
 
         ftp.upload(file, isSmokeTest(letter));

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -80,7 +80,7 @@ public class UploadLettersTask {
 
         ftp.upload(file, isSmokeTest(letter));
 
-        logger.debug(
+        logger.info(
             "Uploaded letter id: {}, messageId: {}, file name: {}, additional data: {}",
             letter.getId(),
             letter.getMessageId(),

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -78,17 +78,15 @@ public class UploadLettersTask {
             letter.getFileContent()
         );
 
+        ftp.upload(file, isSmokeTest(letter));
+
         logger.debug(
-            "Uploading letter id: {}, messageId: {}, file name: {}, additional data: {}",
+            "Uploaded letter id: {}, messageId: {}, file name: {}, additional data: {}",
             letter.getId(),
             letter.getMessageId(),
             file.filename,
             letter.getAdditionalData()
         );
-
-        ftp.upload(file, isSmokeTest(letter));
-
-        logger.info("Successfully uploaded letter {}", letter.getId());
     }
 
     private void markAsUploaded(Letter letter) {


### PR DESCRIPTION
### Change description ###

- Claim number is included in additional data and currently we don't log it.

- CMC doesn't retain letter id but they have claim number so only way to link to filename is claim number.

- This way when we receive request to delete some files then we can lookup in app insights as the claim number and file name can be linked.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```