### PR TITLE
Exclude smoke tests from stale letter report

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTaskTest.java
@@ -84,6 +84,18 @@ public class StaleLettersTaskTest {
     }
 
     @Test
+    public void should_not_report_to_insights_when_there_is_an_unprinted_letter_generated_during_smoke_test() {
+        // given
+        createLetterWithSentToPrintTime(secondBeforeCutOff, UploadLettersTask.SMOKE_TEST_LETTER_TYPE);
+
+        // when
+        task.run();
+
+        // then
+        verify(insights, never()).trackStaleLetter(any(Letter.class));
+    }
+
+    @Test
     public void should_not_pick_up_letter_if_sent_to_print_happened_at_the_cutoff_and_later() {
         // given
         createLetterWithSentToPrintTime(cutOff);
@@ -123,13 +135,13 @@ public class StaleLettersTaskTest {
         verify(insights, never()).trackStaleLetter(any(Letter.class));
     }
 
-    private Letter createLetterWithSentToPrintTime(LocalTime sentToPrintAtTime) {
+    private Letter createLetterWithSentToPrintTime(LocalTime sentToPrintAtTime, String type) {
         Letter letter = new Letter(
             UUID.randomUUID(),
             randomMessageId(),
             "service",
             null,
-            "type",
+            type,
             null,
             false,
             Timestamp.valueOf(LocalDateTime.now())
@@ -146,5 +158,9 @@ public class StaleLettersTaskTest {
         }
 
         return repository.save(letter);
+    }
+
+    private Letter createLetterWithSentToPrintTime(LocalTime sentToPrintAtTime) {
+        return createLetterWithSentToPrintTime(sentToPrintAtTime, "type");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -14,7 +16,12 @@ public interface LetterRepository extends JpaRepository<Letter, UUID> {
 
     Stream<Letter> findByStatus(LetterStatus status);
 
-    Stream<Letter> findByStatusAndSentToPrintAtBefore(LetterStatus status, Timestamp before);
+    @Query("select l from Letter l where l.status = :status and l.type <> :type and l.sentToPrintAt < :before")
+    Stream<Letter> findStaleLetters(
+        @Param("status") LetterStatus status,
+        @Param("type") String type,
+        @Param("before") Timestamp before
+    );
 
     Optional<Letter> findByMessageIdAndStatusOrderByCreatedAtDesc(String messageId, LetterStatus status);
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
@@ -16,6 +16,7 @@ import java.time.LocalTime;
 import java.util.stream.Stream;
 
 import static uk.gov.hmcts.reform.sendletter.tasks.Task.StaleLetters;
+import static uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask.SMOKE_TEST_LETTER_TYPE;
 
 /**
  * Task to run report on unprinted letters and report them to AppInsights.
@@ -48,7 +49,11 @@ public class StaleLettersTask {
 
         logger.info("Started '{}' task with cut-off of {}", StaleLetters, staleCutOff);
 
-        try (Stream<Letter> letters = repo.findByStatusAndSentToPrintAtBefore(LetterStatus.Uploaded, staleCutOff)) {
+        try (Stream<Letter> letters = repo.findStaleLetters(
+            LetterStatus.Uploaded,
+            SMOKE_TEST_LETTER_TYPE,
+            staleCutOff
+        )) {
             long count = letters.peek(insights::trackStaleLetter).count();
             logger.info("Completed '{}' task. Letters found: {}", StaleLetters, count);
         }


### PR DESCRIPTION
### Change description ###

Smoke tests piled up as stale letters gives false information about what's actually stale. Excluding from query

<img width="514" alt="stale-letters" src="https://user-images.githubusercontent.com/1420191/40904979-6336a64e-67d4-11e8-90c8-9ccc5c41b21e.png">

P.S. Spike is from data migration

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
