### PR TITLE
Increase window interval for alert condition

### DIFF
--- a/infrastructure/is_down_alert.tf
+++ b/infrastructure/is_down_alert.tf
@@ -28,7 +28,7 @@ union
 EOF
 
   frequency_in_minutes       = 10
-  time_window_in_minutes     = 15
+  time_window_in_minutes     = 30
   severity_level             = "2"
   action_group_name          = "${module.is-down-action-group.action_group_name}"
   custom_email_subject       = "Send Letter is DOWN"


### PR DESCRIPTION
### Change description ###

15 minutes is too small window for assurance that logs appear in app insights. In case 500 telemetry items are not accumulated it should publish every 5 (default?) seconds. Maximum is 5 minutes according to in process telemetry channel.

Ran query in various range reported in email thread - all seems to be fine so must be some latency related issue.

Will inspect future alerts with new window time

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
