### PR TITLE
[PREVIEW] Update alert query

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -31,11 +31,14 @@ withPipeline(type , product, component) {
 
   enableDbMigration()
   enableSlackNotifications(channel)
-  loadVaultSecrets(secrets)
 
   onPR {
-    loadVaultSecrets([
+    loadVaultSecrets(secrets + [
       secret('send-letter-failure-email', 'TEST_FAILURE_EMAIL')
     ])
+  }
+
+  onNonPR {
+    loadVaultSecrets(secrets)
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -32,4 +32,10 @@ withPipeline(type , product, component) {
   enableDbMigration()
   enableSlackNotifications(channel)
   loadVaultSecrets(secrets)
+
+  onPR {
+    loadVaultSecrets([
+      secret('send-letter-failure-email', 'TEST_FAILURE_EMAIL')
+    ])
+  }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -31,5 +31,14 @@ properties([
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
   enableDbMigration()
-  loadVaultSecrets(secrets)
+
+  onPR {
+    loadVaultSecrets(secrets + [
+      secret('send-letter-failure-email', 'TEST_FAILURE_EMAIL')
+    ])
+  }
+
+  onNonPR {
+    loadVaultSecrets(secrets)
+  }
 }

--- a/infrastructure/is_down_alert.tf
+++ b/infrastructure/is_down_alert.tf
@@ -9,30 +9,36 @@ module "send-letter-up-alert" {
   app_insights_query = <<EOF
 union
   (dependencies
+    | where timestamp > ago(3h)
     | where data == 'FtpFileUploaded' and success =~ 'true'
-    | summarize ['name'] = 'uploaded', ['counter'] = sum(itemCount)
+    | summarize ['name'] = 'uploaded', ['counter'] = sum(itemCount) by ['timecut'] = bin(timestamp, 30m)
   ),
   (requests
+    | where timestamp > ago(3h)
     | where name == 'POST SendLetterController/sendLetter' and success =~ 'true'
     | where tostring(operation_SyntheticSource) == ''
-    | summarize ['name'] = 'received', ['counter'] = sum(itemCount)
+    | summarize ['name'] = 'received', ['counter'] = sum(itemCount) by ['timecut'] = bin(timestamp, 30m)
   ),
   (traces
+    | where timestamp > ago(3h)
     | extend logger = customDimensions.LoggerName
     | where logger == 'uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask' and message has 'FTP downtime'
-    | summarize ['name'] = 'downtime', ['counter'] = sum(itemCount)
+    | summarize ['name'] = 'downtime', ['counter'] = sum(itemCount) by ['timecut'] = bin(timestamp, 30m)
   )
-| evaluate pivot(name, sum(counter))
-| project ['is_operational'] = iif(received > 0 and downtime > 0, true, iif(received > 0, uploaded > 0, true))
+| summarize ['received'] = sum(iif(name == 'received', counter, 0)),
+            ['uploaded'] = sum(iif(name == 'uploaded', counter, 0)),
+            ['downtime'] = sum(iif(name == 'downtime', counter, 0)) by bin(timecut, 30m)
+| project timecut, ['is_operational'] = iif(received > 0 and downtime > 0, true, iif(received > 0, uploaded > 0, true))
 | where is_operational == false
 EOF
 
   frequency_in_minutes       = 10
+  // window no longer matters as it is defined in the query. but it is a requirement for module
   time_window_in_minutes     = 30
   severity_level             = "2"
   action_group_name          = "${module.is-down-action-group.action_group_name}"
   custom_email_subject       = "Send Letter is DOWN"
   trigger_threshold_operator = "GreaterThan"
-  trigger_threshold          = 0
+  trigger_threshold          = 3
   resourcegroup_name         = "${azurerm_resource_group.rg.name}"
 }

--- a/infrastructure/is_down_alert_action_group.tf
+++ b/infrastructure/is_down_alert_action_group.tf
@@ -1,6 +1,12 @@
-data "azurerm_key_vault_secret" "sl_email_secret" {
+data "azurerm_key_vault_secret" "source_sl_email_secret" {
   name      = "send-letter-failure-email"
   vault_uri = "${local.permanent_vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "sl_email_secret" {
+  name      = "send-letter-failure-email"
+  value     = "${data.azurerm_key_vault_secret.source_sl_email_secret.value}"
+  vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 
 module "is-down-action-group" {
@@ -12,7 +18,7 @@ module "is-down-action-group" {
   action_group_name      = "Send Letter is DOWN Alert - ${var.env}"
   short_name             = "SL_is_down"
   email_receiver_name    = "Send Letter Alerts"
-  email_receiver_address = "${data.azurerm_key_vault_secret.sl_email_secret.value}"
+  email_receiver_address = "${data.azurerm_key_vault_secret.source_sl_email_secret.value}"
 }
 
 output "action_group_name" {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -40,4 +40,8 @@ output "test_encryption_enabled" {
   value = "${var.encyption_enabled}"
 }
 
+output "test_failure_email" {
+  value = "ignore@failure.email"
+}
+
 #endregion

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -40,8 +40,4 @@ output "test_encryption_enabled" {
   value = "${var.encyption_enabled}"
 }
 
-output "test_failure_email" {
-  value = "ignore@failure.email"
-}
-
 #endregion


### PR DESCRIPTION
### Change description ###

#### Notes

- trying to automate pr build by including some dummy email for alert which is required by terraform plan/apply step
- improve alert query

#### Summary

Query overrides requirement of time window in which the alerting condition is checked. Module requires specific window in minutes and only judge by that. Incorporating it in the query by 5 additional windows making the interval equal to 3 hours instead.
Same measurements are taken and every half an hour and summarising to anticipated `is_operational` flag.
Update gives opportunity to increase threshold which can be interpreted as _correct_ for given failure/alert: only stream of them makes valid assumption whether one can question service is down or not

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
