### PR TITLE
[PREVIEW] Bugfix for functional test for pdf endpoint

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
@@ -34,7 +34,7 @@ public class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
-                validatePdfFile(letterId, sftp, sftpFile, 1);
+                validatePdfFile(letterId, sftp, sftpFile, 2);
             }
         }
     }
@@ -53,7 +53,7 @@ public class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
-                validatePdfFile(letterId, sftp, sftpFile, 2);
+                validatePdfFile(letterId, sftp, sftpFile, 4);
             }
         }
     }


### PR DESCRIPTION
### Change description ###

I thought this was covered in PR pipeline. Have no idea why it failed during the last build #246. Besides, we know we populate with blank page each document so it's kind of obvious

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
