### PR TITLE
updating to logging 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ flyway {
 }
 
 group = 'uk.gov.hmcts.reform'
-version = '0.0.1'
+version = '0.0.2'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -158,7 +158,7 @@ repositories {
 }
 
 def versions = [
-  reformLogging: '3.0.4',
+  reformLogging: '4.0.0',
   shedlock: '1.1.0',
   springfoxSwagger: '2.9.2'
 ]
@@ -189,7 +189,7 @@ dependencies {
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.4'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '2.0.0'
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.4.0'
   compile group: 'uk.gov.hmcts.reform', name: 'pdf-generator', version: '1.0.2'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Dec 18 09:09:22 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
@@ -14,9 +14,7 @@ import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
-import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
 import uk.gov.hmcts.reform.sendletter.exception.DuplexException;
-import uk.gov.hmcts.reform.sendletter.exception.InternalServerException;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.exception.ServiceNotConfiguredException;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
@@ -99,13 +97,7 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<Void> handleInternalException(Exception exc) {
-        Throwable exception = exc;
-
-        if (!(exc instanceof AbstractLoggingException)) {
-            exception = new InternalServerException(exc);
-        }
-
-        log.error(exc.getMessage(), exception);
+        log.error(exc.getMessage(), exc);
         return status(INTERNAL_SERVER_ERROR).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/DocumentZipException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/DocumentZipException.java
@@ -1,15 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class DocumentZipException extends UnknownErrorCodeException {
+public class DocumentZipException extends RuntimeException {
 
     public DocumentZipException(Throwable cause) {
-        super(AlertLevel.P1, cause);
+        super(cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/DuplexException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/DuplexException.java
@@ -1,14 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class DuplexException extends UnknownErrorCodeException {
+public class DuplexException extends RuntimeException {
     public DuplexException(Throwable cause) {
-        super(AlertLevel.P2, cause);
+        super(cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/FtpException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/FtpException.java
@@ -1,14 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class FtpException extends UnknownErrorCodeException {
+public class FtpException extends RuntimeException {
     public FtpException(String message, Throwable cause) {
-        super(AlertLevel.P1, message, cause);
+        super(message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/InternalServerException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/InternalServerException.java
@@ -1,15 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class InternalServerException extends UnknownErrorCodeException {
-
+public class InternalServerException extends RuntimeException {
     public InternalServerException(Throwable cause) {
-        super(AlertLevel.P1, cause);
+        super(cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/LetterNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/LetterNotFoundException.java
@@ -1,18 +1,11 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
 import java.util.UUID;
 
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class LetterNotFoundException extends UnknownErrorCodeException {
+public class LetterNotFoundException extends RuntimeException {
 
     public LetterNotFoundException(String letterId, Throwable cause) {
-        super(AlertLevel.P4, "Letter with ID '" + letterId + "' not found", cause);
+        super("Letter with ID '" + letterId + "' not found", cause);
     }
 
     public LetterNotFoundException(UUID id) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/PdfMergeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/PdfMergeException.java
@@ -1,14 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class PdfMergeException extends UnknownErrorCodeException {
+public class PdfMergeException extends RuntimeException {
     public PdfMergeException(String message, Throwable cause) {
-        super(AlertLevel.P3, message, cause);
+        super(message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/PendingMigrationScriptException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/PendingMigrationScriptException.java
@@ -1,15 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class PendingMigrationScriptException extends UnknownErrorCodeException {
+public class PendingMigrationScriptException extends RuntimeException {
 
     public PendingMigrationScriptException(String script) {
-        super(AlertLevel.P1, "Found migration not yet applied " + script);
+        super("Found migration not yet applied " + script);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/ReportParsingException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/ReportParsingException.java
@@ -1,14 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class ReportParsingException extends UnknownErrorCodeException {
+public class ReportParsingException extends RuntimeException {
     public ReportParsingException(Throwable cause) {
-        super(AlertLevel.P2, cause);
+        super(cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/ServiceNotConfiguredException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/ServiceNotConfiguredException.java
@@ -1,14 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class ServiceNotConfiguredException extends UnknownErrorCodeException {
+public class ServiceNotConfiguredException extends RuntimeException {
     public ServiceNotConfiguredException(String message) {
-        super(AlertLevel.P3, message);
+        super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/TaskRunnerException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/TaskRunnerException.java
@@ -1,15 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class TaskRunnerException extends UnknownErrorCodeException {
+public class TaskRunnerException extends RuntimeException {
 
     public TaskRunnerException(Throwable cause) {
-        super(AlertLevel.P1, cause);
+        super(cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnableToExtractIdFromFileNameException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnableToExtractIdFromFileNameException.java
@@ -1,19 +1,12 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UnableToExtractIdFromFileNameException extends UnknownErrorCodeException {
+public class UnableToExtractIdFromFileNameException extends RuntimeException {
 
     public UnableToExtractIdFromFileNameException(Exception inner) {
-        super(AlertLevel.P4, inner);
+        super(inner);
     }
 
     public UnableToExtractIdFromFileNameException(String message) {
-        super(AlertLevel.P4, message);
+        super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnauthenticatedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnauthenticatedException.java
@@ -1,14 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UnauthenticatedException extends UnknownErrorCodeException {
+public class UnauthenticatedException extends RuntimeException {
     public UnauthenticatedException(String message) {
-        super(AlertLevel.P3, message);
+        super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnsupportedLetterRequestTypeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnsupportedLetterRequestTypeException.java
@@ -1,10 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.exception;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-public class UnsupportedLetterRequestTypeException extends UnknownErrorCodeException {
+public class UnsupportedLetterRequestTypeException extends RuntimeException {
     public UnsupportedLetterRequestTypeException() {
-        super(AlertLevel.P1, "Unsupported letter request type");
+        super("Unsupported letter request type");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/encryption/UnableToLoadPgpPublicKeyException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/encryption/UnableToLoadPgpPublicKeyException.java
@@ -1,17 +1,10 @@
 package uk.gov.hmcts.reform.sendletter.services.encryption;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UnableToLoadPgpPublicKeyException extends UnknownErrorCodeException {
+public class UnableToLoadPgpPublicKeyException extends RuntimeException {
 
     private static final long serialVersionUID = -5621910255408117685L;
 
     public UnableToLoadPgpPublicKeyException(Throwable cause) {
-        super(AlertLevel.P1, cause);
+        super(cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/encryption/UnableToPgpEncryptZipFileException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/encryption/UnableToPgpEncryptZipFileException.java
@@ -1,17 +1,10 @@
 package uk.gov.hmcts.reform.sendletter.services.encryption;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UnableToPgpEncryptZipFileException extends UnknownErrorCodeException {
+public class UnableToPgpEncryptZipFileException extends RuntimeException {
 
     private static final long serialVersionUID = 262685880220521685L;
 
     public UnableToPgpEncryptZipFileException(Throwable cause) {
-        super(AlertLevel.P1, cause);
+        super(cause);
     }
 }


### PR DESCRIPTION
### Change description ###
Moving to logging major revision of 4.0.0
The proprietary exceptions have been removed consequently the inheritance has to be removed.
This should also improve performance of the system by vastly reducing the performance impact of logging.

