### PR TITLE
Make method name clearer

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
@@ -73,7 +73,7 @@ public class LetterServiceTest {
 
     @Test
     public void generates_and_saves_zipped_pdf() throws IOException {
-        UUID id = service.send(SampleData.letterRequest(), SERVICE_NAME);
+        UUID id = service.save(SampleData.letterRequest(), SERVICE_NAME);
 
         Letter result = letterRepository.findById(id).get();
         PdfHelper.validateZippedPdf(result.getFileContent());
@@ -83,14 +83,14 @@ public class LetterServiceTest {
     public void returns_same_id_on_resubmit() throws IOException {
         // given
         LetterRequest sampleRequest = SampleData.letterRequest();
-        UUID id1 = service.send(sampleRequest, SERVICE_NAME);
+        UUID id1 = service.save(sampleRequest, SERVICE_NAME);
         Letter letter = letterRepository.findById(id1).get();
 
         // and
         assertThat(letter.getStatus()).isEqualByComparingTo(Created);
 
         // when
-        UUID id2 = service.send(sampleRequest, SERVICE_NAME);
+        UUID id2 = service.save(sampleRequest, SERVICE_NAME);
 
         // then
         assertThat(id1).isEqualByComparingTo(id2);
@@ -103,7 +103,7 @@ public class LetterServiceTest {
     public void saves_an_new_letter_if_previous_one_has_been_sent_to_print() throws IOException {
         // given
         LetterRequest sampleRequest = SampleData.letterRequest();
-        UUID id1 = service.send(sampleRequest, SERVICE_NAME);
+        UUID id1 = service.save(sampleRequest, SERVICE_NAME);
         Letter letter = letterRepository.findById(id1).get();
 
         // and
@@ -112,7 +112,7 @@ public class LetterServiceTest {
         // when
         letter.setStatus(Uploaded);
         letterRepository.saveAndFlush(letter);
-        UUID id2 = service.send(sampleRequest, SERVICE_NAME);
+        UUID id2 = service.save(sampleRequest, SERVICE_NAME);
 
         // then
         assertThat(id1).isNotEqualByComparingTo(id2);
@@ -123,13 +123,13 @@ public class LetterServiceTest {
 
     @Test
     public void should_not_allow_null_service_name() {
-        assertThatThrownBy(() -> service.send(SampleData.letterRequest(), null))
+        assertThatThrownBy(() -> service.save(SampleData.letterRequest(), null))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     public void should_not_allow_empty_service_name() {
-        assertThatThrownBy(() -> service.send(SampleData.letterRequest(), ""))
+        assertThatThrownBy(() -> service.save(SampleData.letterRequest(), ""))
             .isInstanceOf(IllegalStateException.class);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceWithEncryptionEnabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceWithEncryptionEnabledTest.java
@@ -71,7 +71,7 @@ public class LetterServiceWithEncryptionEnabledTest {
             serviceFolderMapping
         );
 
-        UUID id = service.send(letterRequest, SERVICE_NAME);
+        UUID id = service.save(letterRequest, SERVICE_NAME);
 
         Letter letterInDb = letterRepository.findById(id).get();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -78,7 +78,7 @@ public class UploadLettersTaskTest {
 
     @Test
     public void uploads_file_to_sftp_and_sets_letter_status_to_uploaded() throws Exception {
-        UUID id = letterService.send(SampleData.letterRequest(), "bulkprint");
+        UUID id = letterService.save(SampleData.letterRequest(), "bulkprint");
         UploadLettersTask task = new UploadLettersTask(
             repository,
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
@@ -112,9 +112,9 @@ public class UploadLettersTaskTest {
     @Test
     public void should_fail_to_upload_to_sftp_and_stop_from_uploading_any_other_letters() throws Exception {
         // given
-        UUID id = letterService.send(SampleData.letterRequest(), "bulkprint");
+        UUID id = letterService.save(SampleData.letterRequest(), "bulkprint");
         // additional letter to verify upload loop broke and zipper was never called again
-        letterService.send(SampleData.letterRequest(), "bulkprint");
+        letterService.save(SampleData.letterRequest(), "bulkprint");
 
         // and
         UploadLettersTask task = new UploadLettersTask(
@@ -151,7 +151,7 @@ public class UploadLettersTaskTest {
         // Twice the batch size.
         int letterCount = 20;
         IntStream.rangeClosed(1, letterCount).forEach(
-            x -> letterService.send(SampleData.letterRequest(), "bulkprint"));
+            x -> letterService.save(SampleData.letterRequest(), "bulkprint"));
 
         UploadLettersTask task = new UploadLettersTask(
             repository,

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/SendLetterController.java
@@ -61,7 +61,7 @@ public class SendLetterController {
         @Valid @RequestBody LetterRequest letter
     ) {
         String serviceName = authService.authenticate(serviceAuthHeader);
-        UUID letterId = letterService.send(letter, serviceName);
+        UUID letterId = letterService.save(letter, serviceName);
 
         return ok().body(new SendLetterResponse(letterId));
     }
@@ -78,7 +78,7 @@ public class SendLetterController {
         @Valid @RequestBody LetterWithPdfsRequest letter
     ) {
         String serviceName = authService.authenticate(serviceAuthHeader);
-        UUID letterId = letterService.send(letter, serviceName);
+        UUID letterId = letterService.save(letter, serviceName);
 
         return ok().body(new SendLetterResponse(letterId));
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -69,7 +69,7 @@ public class LetterService {
     }
 
     @Transactional
-    public UUID send(ILetterRequest letter, String serviceName) {
+    public UUID save(ILetterRequest letter, String serviceName) {
         String messageId = generateChecksum(letter);
         Asserts.notEmpty(serviceName, "serviceName");
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/sendlettercontroller/SendLetterControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/sendlettercontroller/SendLetterControllerTest.java
@@ -52,14 +52,14 @@ public class SendLetterControllerTest {
         UUID letterId = UUID.randomUUID();
 
         given(authService.authenticate("auth-header-value")).willReturn("service-name");
-        given(letterService.send(any(LetterRequest.class), anyString())).willReturn(letterId);
+        given(letterService.save(any(LetterRequest.class), anyString())).willReturn(letterId);
 
         sendLetter(readResource("controller/letter/v1/letter.json"))
             .andExpect(status().isOk())
             .andExpect(content().json("{\"letter_id\":" + letterId + "}"));
 
         verify(authService).authenticate("auth-header-value");
-        verify(letterService).send(any(LetterRequest.class), eq("service-name"));
+        verify(letterService).save(any(LetterRequest.class), eq("service-name"));
         verifyNoMoreInteractions(authService, letterService);
     }
 
@@ -67,7 +67,7 @@ public class SendLetterControllerTest {
     public void should_return_400_client_error_when_invalid_letter_is_sent() throws Exception {
         sendLetter("").andExpect(status().isBadRequest());
 
-        verify(letterService, never()).send(any(LetterRequest.class), anyString());
+        verify(letterService, never()).save(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents\",\"message\":\"size must be between 1 and 10\"}]}"));
 
-        verify(letterService, never()).send(any(LetterRequest.class), anyString());
+        verify(letterService, never()).save(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"type\",\"message\":\"must not be empty\"}]}"));
 
-        verify(letterService, never()).send(any(LetterRequest.class), anyString());
+        verify(letterService, never()).save(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents[0].template\",\"message\":\"must not be empty\"}]}"));
 
-        verify(letterService, never()).send(any(LetterRequest.class), anyString());
+        verify(letterService, never()).save(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents[0].values\",\"message\":\"must not be empty\"}]}"));
 
-        verify(letterService, never()).send(any(LetterRequest.class), anyString());
+        verify(letterService, never()).save(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -119,7 +119,7 @@ public class SendLetterControllerTest {
             .andExpect(content()
                 .json("{\"errors\":[{\"field_name\":\"documents\",\"message\":\"size must be between 1 and 10\"}]}"));
 
-        verify(letterService, never()).send(any(LetterRequest.class), anyString());
+        verify(letterService, never()).save(any(LetterRequest.class), anyString());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class SendLetterControllerTest {
     @Test
     public void should_return_422_if_service_throws_ServiceNotConfiguredException() throws Exception {
         given(authService.authenticate("auth-header-value")).willReturn("service-name");
-        given(letterService.send(any(), any())).willThrow(new ServiceNotConfiguredException("invalid service"));
+        given(letterService.save(any(), any())).willThrow(new ServiceNotConfiguredException("invalid service"));
 
         sendLetter(readResource("controller/letter/v1/letter.json"))
             .andExpect(status().is(422));
@@ -161,7 +161,7 @@ public class SendLetterControllerTest {
         }
 
         verify(letterService, times(supportedContentTypes.size()))
-            .send(any(LetterRequest.class), anyString());
+            .save(any(LetterRequest.class), anyString());
     }
 
     private ResultActions sendLetter(String json) throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/sendlettercontroller/SendLetterWithPdfsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/sendlettercontroller/SendLetterWithPdfsControllerTest.java
@@ -48,7 +48,7 @@ public class SendLetterWithPdfsControllerTest {
         sendLetter(validJson);
 
         // then
-        verify(letterService).send(any(LetterWithPdfsRequest.class), anyString());
+        verify(letterService).save(any(LetterWithPdfsRequest.class), anyString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterServiceTest.java
@@ -55,7 +55,7 @@ public class LetterServiceTest {
         LetterRequest letter = SampleData.letterRequest();
 
         // when
-        service.send(letter, "some_service");
+        service.save(letter, "some_service");
 
         // then
         verify(pdfCreator).createFromTemplates(letter.documents);
@@ -70,7 +70,7 @@ public class LetterServiceTest {
         LetterWithPdfsRequest letter = SampleData.letterWithPdfsRequest();
 
         // when
-        service.send(letter, "some_service");
+        service.save(letter, "some_service");
 
         // then
         verify(pdfCreator).createFromBase64Pdfs(letter.documents);
@@ -90,7 +90,7 @@ public class LetterServiceTest {
         when(zipper.zip(any(PdfDoc.class))).thenReturn(inputZipFile);
 
         // when
-        service.send(letter, "some_service");
+        service.save(letter, "some_service");
 
         // then
         verify(pdfCreator).createFromTemplates(letter.documents);
@@ -111,7 +111,7 @@ public class LetterServiceTest {
         when(zipper.zip(any(PdfDoc.class))).thenReturn(inputZipFile);
 
         // when
-        service.send(letter, "some_service");
+        service.save(letter, "some_service");
 
         // then
         verify(pdfCreator).createFromBase64Pdfs(letter.documents);
@@ -140,7 +140,7 @@ public class LetterServiceTest {
 
         // when
         Throwable err =
-            catchThrowable(() -> service.send(SampleData.letterWithPdfsRequest(), serviceWithoutFolderConfigured));
+            catchThrowable(() -> service.save(SampleData.letterWithPdfsRequest(), serviceWithoutFolderConfigured));
 
         // then
         assertThat(err)


### PR DESCRIPTION
Rename service method from `send` to `save` to avoid any confusion in the future.
The service only saves the letter data in the db.
It is later sent by the scheduled job.