### PR TITLE
Increase max wait time in functional tests

### DIFF
--- a/src/functionalTest/resources/application.properties
+++ b/src/functionalTest/resources/application.properties
@@ -9,5 +9,5 @@ ftp-target-folder=${FTP_TARGET_FOLDER}
 ftp-user=${TEST_FTP_USER}
 ftp-private-key=${TEST_FTP_PRIVATE_KEY}
 ftp-public-key=${TEST_FTP_PUBLIC_KEY}
-max-wait-for-ftp-file-in-ms=35000
+max-wait-for-ftp-file-in-ms=45000
 encryption.enabled=${TEST_ENCRYPTION_ENABLED}


### PR DESCRIPTION
Job runs every 30 seconds, that leaves 5 seconds for the test file to be sent to FTP in pessimistic scenarios.
Under heavy load, the test message needs to wait for its turn.