### PR TITLE
Continue processing other files if folder for given file is not configured

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/FtpUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/FtpUploadTest.java
@@ -24,7 +24,7 @@ public class FtpUploadTest {
         FileToSend doc = new FileToSend("hello.zip", "world".getBytes());
         try (LocalSftpServer server = LocalSftpServer.create()) {
             FtpClient client = FtpHelper.getSuccessfulClient(LocalSftpServer.port);
-            client.upload(doc, false, "bulkprint");
+            client.upload(doc, false, LocalSftpServer.SERVICE_FOLDER);
             File[] files = server.lettersFolder.listFiles();
             assertThat(files.length).isEqualTo(1);
             String content = new String(Files.toByteArray(files[0]));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/FtpUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/FtpUploadTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sendletter.services;
 
 import com.google.common.io.Files;
 import org.junit.Test;
-import uk.gov.hmcts.reform.sendletter.exception.ServiceNotConfiguredException;
 import uk.gov.hmcts.reform.sendletter.helper.FtpHelper;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
@@ -10,7 +9,6 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class FtpUploadTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/FtpUploadTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/FtpUploadTest.java
@@ -33,21 +33,4 @@ public class FtpUploadTest {
             assertThat(content).isEqualTo("world");
         }
     }
-
-    @Test
-    public void should_not_upload_file_when_service_is_not_configured() throws Exception {
-        //given
-        FileToSend doc = new FileToSend("hello.zip", "world".getBytes());
-
-        try (LocalSftpServer server = LocalSftpServer.create()) {
-            FtpClient client = FtpHelper.getSuccessfulClient(LocalSftpServer.port);
-
-            Throwable thrown = catchThrowable(() -> client.upload(doc, false, "unconfigured-service"));
-
-            //then
-            assertThat(thrown)
-                .isInstanceOf(ServiceNotConfiguredException.class)
-                .hasMessage("Service unconfigured-service is not configured to use bulk-print");
-        }
-    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LocalSftpServer.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/services/LocalSftpServer.java
@@ -24,6 +24,7 @@ public final class LocalSftpServer implements AutoCloseable {
     // These determine where our pdfs and xerox reports are stored.
     public static final String LETTERS_FOLDER_NAME = "letters";
     public static final String REPORT_FOLDER_NAME = "reports";
+    public static final String SERVICE_FOLDER = "BULKPRINT";
 
     public final File rootFolder;
 
@@ -47,9 +48,9 @@ public final class LocalSftpServer implements AutoCloseable {
         File root = tmp.getRoot();
         File workingDirectory = new File(root, LETTERS_FOLDER_NAME);
         workingDirectory.mkdir();
-        File reportDirectory = new File(root, "reports");
+        File reportDirectory = new File(root, REPORT_FOLDER_NAME);
         reportDirectory.mkdir();
-        File lettersFolder = new File(workingDirectory, "BULKPRINT");
+        File lettersFolder = new File(workingDirectory, SERVICE_FOLDER);
         lettersFolder.mkdir();
         return new LocalSftpServer(root, lettersFolder, reportDirectory);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -63,7 +63,7 @@ public class UploadLettersTaskTest {
     @Before
     public void setUp() {
         when(availabilityChecker.isFtpAvailable(any(LocalTime.class))).thenReturn(true);
-        when(serviceFolderMapping.getFolderFor(any())).thenReturn(Optional.of("some_folder"));
+        when(serviceFolderMapping.getFolderFor(any())).thenReturn(Optional.of(LocalSftpServer.SERVICE_FOLDER));
 
         this.letterService = new LetterService(
             new PdfCreator(new DuplexPreparator(), new HTMLToPDFConverter()::convert),
@@ -83,6 +83,7 @@ public class UploadLettersTaskTest {
             repository,
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
             availabilityChecker,
+            serviceFolderMapping,
             insights
         );
 
@@ -121,6 +122,7 @@ public class UploadLettersTaskTest {
             repository,
             FtpHelper.getFailingClient(LocalSftpServer.port),
             availabilityChecker,
+            serviceFolderMapping,
             insights
         );
 
@@ -157,6 +159,7 @@ public class UploadLettersTaskTest {
             repository,
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
             availabilityChecker,
+            serviceFolderMapping,
             insights
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -5,14 +5,12 @@ import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.sftp.SFTPFileTransfer;
 import net.schmizz.sshj.xfer.LocalSourceFile;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties;
 import uk.gov.hmcts.reform.sendletter.exception.FtpException;
-import uk.gov.hmcts.reform.sendletter.exception.ServiceNotConfiguredException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.InMemoryDownloadedFile;
 import uk.gov.hmcts.reform.sendletter.model.Report;
@@ -51,15 +49,13 @@ public class FtpClient {
     }
     // endregion
 
-    public void upload(LocalSourceFile file, boolean isSmokeTestFile, String service) {
+    public void upload(LocalSourceFile file, boolean isSmokeTestFile, String serviceFolder) {
         Instant now = Instant.now();
 
         runWith(sftp -> {
             boolean isSuccess = false;
 
             try {
-                String serviceFolder = getServiceFolderMapping(service);
-
                 String folder = isSmokeTestFile
                     ? configProperties.getSmokeTestTargetFolder()
                     : String.join("/", configProperties.getTargetFolder(), serviceFolder);
@@ -178,14 +174,4 @@ public class FtpClient {
             && resourceInfo.getName().toLowerCase(Locale.getDefault()).endsWith(".csv");
     }
 
-    private String getServiceFolderMapping(String service) {
-        String serviceFolder = configProperties.getServiceFolders().getOrDefault(service, null);
-
-        if (StringUtils.isEmpty(serviceFolder)) {
-            throw new ServiceNotConfiguredException(
-                String.format("Service %s is not configured to use bulk-print", service)
-            );
-        }
-        return serviceFolder;
-    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
@@ -12,18 +12,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties;
 import uk.gov.hmcts.reform.sendletter.exception.FtpException;
-import uk.gov.hmcts.reform.sendletter.exception.ServiceNotConfiguredException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.Report;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -90,10 +86,6 @@ public class FtpClientTest {
         given(ftpProps.getSmokeTestTargetFolder()).willReturn("smoke");
         given(ftpProps.getTargetFolder()).willReturn("regular");
 
-        Map<String, String> serviceFolderMappings = new HashMap<>();
-        serviceFolderMappings.put("cmc", "CMC");
-        given(ftpProps.getServiceFolders()).willReturn(serviceFolderMappings);
-
         // when
         client.upload(new FileToSend("hello.zip", "hello".getBytes()), true, "cmc");
 
@@ -116,46 +108,8 @@ public class FtpClientTest {
     }
 
     @Test
-    public void should_track_failure_when_uploading_file_for_unconfigured_service() {
-        //given
-        given(ftpProps.getServiceFolders()).willReturn(emptyMap());
-
-        // when
-        Throwable exception = catchThrowable(() ->
-            client.upload(new FileToSend("goodbye.zip", "goodbye".getBytes()), false, "unconfigured-service")
-        );
-
-        // then
-        assertThat(exception)
-            .isInstanceOf(ServiceNotConfiguredException.class)
-            .hasMessage("Service unconfigured-service is not configured to use bulk-print");
-    }
-
-    @Test
-    public void should_track_failure_when_uploading_file_for_service_configured_with_empty_folder_name() {
-        //given
-        Map<String, String> serviceFolderMappings = new HashMap<>();
-        serviceFolderMappings.put("unconfigured-service", "");
-        given(ftpProps.getServiceFolders()).willReturn(serviceFolderMappings);
-
-        // when
-        Throwable exception = catchThrowable(() ->
-            client.upload(new FileToSend("goodbye.zip", "goodbye".getBytes()), false, "unconfigured-service")
-        );
-
-        // then
-        assertThat(exception)
-            .isInstanceOf(ServiceNotConfiguredException.class)
-            .hasMessage("Service unconfigured-service is not configured to use bulk-print");
-    }
-
-    @Test
     public void should_track_failure_when_trying_to_upload_new_file() throws IOException {
         // given
-        Map<String, String> serviceFolderMappings = new HashMap<>();
-        serviceFolderMappings.put("cmc", "CMC");
-        given(ftpProps.getServiceFolders()).willReturn(serviceFolderMappings);
-
         willThrow(IOException.class).given(sftpFileTransfer).upload(any(LocalSourceFile.class), anyString());
 
         // when

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -12,10 +12,13 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
+import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -24,6 +27,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Created;
 import static uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask.SMOKE_TEST_LETTER_TYPE;
 
@@ -37,6 +41,8 @@ public class UploadLettersTaskTest {
     @Mock
     private FtpAvailabilityChecker availabilityChecker;
     @Mock
+    private ServiceFolderMapping serviceFolderMapping;
+    @Mock
     private AppInsights insights;
 
     private UploadLettersTask task;
@@ -44,7 +50,8 @@ public class UploadLettersTaskTest {
     @Before
     public void setUp() {
         given(availabilityChecker.isFtpAvailable(any(LocalTime.class))).willReturn(true);
-        this.task = new UploadLettersTask(repo, ftpClient, availabilityChecker, insights);
+        given(serviceFolderMapping.getFolderFor(any())).willReturn(Optional.of("some_folder"));
+        this.task = new UploadLettersTask(repo, ftpClient, availabilityChecker, serviceFolderMapping, insights);
     }
 
     @After
@@ -74,6 +81,29 @@ public class UploadLettersTaskTest {
         verify(repo, never()).findByStatus(eq(Created));
     }
 
+    @Test
+    public void should_skip_letter_if_folder_for_its_service_is_not_configured() {
+        reset(serviceFolderMapping);
+
+        givenDbContains(
+            letterForService("service_A"),
+            letterForService("service_B"),
+            letterForService("service_C")
+        );
+
+        given(serviceFolderMapping.getFolderFor(eq("service_A"))).willReturn(Optional.of("folder_A"));
+        given(serviceFolderMapping.getFolderFor(eq("service_B"))).willReturn(Optional.empty());
+        given(serviceFolderMapping.getFolderFor(eq("service_C"))).willReturn(Optional.of("folder_C"));
+
+        // when
+        task.run();
+
+        // then
+        verify(ftpClient).upload(any(), eq(false), eq("folder_A"));
+        verify(ftpClient).upload(any(), eq(false), eq("folder_C"));
+        verifyNoMoreInteractions(ftpClient);
+    }
+
     private Letter letterOfType(String type) {
         return new Letter(
             UUID.randomUUID(),
@@ -87,10 +117,23 @@ public class UploadLettersTaskTest {
         );
     }
 
+    private Letter letterForService(String serviceName) {
+        return new Letter(
+            UUID.randomUUID(),
+            "msgId",
+            serviceName,
+            null,
+            "type",
+            "hello".getBytes(),
+            true,
+            Timestamp.valueOf(LocalDateTime.now())
+        );
+    }
+
     @SuppressWarnings("unchecked")
-    private void givenDbContains(Letter letter) {
+    private void givenDbContains(Letter... letters) {
         // Return letter on first call, then empty list.
         given(repo.findFirst10ByStatus(eq(Created)))
-            .willReturn(Lists.newArrayList(letter)).willReturn(Lists.newArrayList());
+            .willReturn(Arrays.asList(letters)).willReturn(Lists.newArrayList());
     }
 }


### PR DESCRIPTION
just in case...

Removing the logic of determining the target folder from FTP client.
The caller sends the FTP client service folder that should be used.
When folder for given service is not found, this fact is logged and the client is never called.