### PR TITLE
Adapt service to AKS builds

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/FlywayConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/FlywayConfiguration.java
@@ -24,7 +24,14 @@ import uk.gov.hmcts.reform.sendletter.data.migration.FlywayNoOpStrategy;
 public class FlywayConfiguration {
 
     @Bean
+    @ConditionalOnProperty(prefix = "flyway.noop", name = "strategy", matchIfMissing = true)
     public FlywayMigrationStrategy flywayMigrationStrategy() {
         return new FlywayNoOpStrategy();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "flyway.noop", name = "strategy", havingValue = "false")
+    public FlywayMigrationStrategy flywayVoidMigrationStrategy() {
+        return null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/FtpConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/FtpConfigProperties.java
@@ -104,6 +104,10 @@ public class FtpConfigProperties {
     public void setPrivateKey(String privateKey) {
         String wrapper = "-----";
 
+        // this is done so private key is loaded to library without throwing an exception
+        // causing application to crash.
+        // origin: platform specific. noticed only when building aks dockerised platform
+        // by definition private key must be wrapped with newlines
         this.privateKey = privateKey == null ? privateKey : privateKey
             .replace(wrapper + " ", wrapper + "\n")
             .replace(" " + wrapper, "\n" + wrapper);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/FtpConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/FtpConfigProperties.java
@@ -102,7 +102,11 @@ public class FtpConfigProperties {
     }
 
     public void setPrivateKey(String privateKey) {
-        this.privateKey = privateKey;
+        String wrapper = "-----";
+
+        this.privateKey = privateKey == null ? privateKey : privateKey
+            .replace(wrapper + " ", wrapper + "\n")
+            .replace(" " + wrapper, "\n" + wrapper);
     }
 
     public String getTargetFolder() {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
@@ -78,6 +78,12 @@ public class PdfCreatorTest {
         assertThat(actualPdfPage1).hasSameContentAs(expectedPdfPage1);
         assertThat(actualPdfPage2).hasSameContentAs(expectedPdfPage2);
 
+        actualPdfPage1.close();
+        actualPdfPage2.close();
+        expectedPdfPage1.close();
+        expectedPdfPage2.close();
+
+        // and
         verify(duplexPreparator, times(2)).prepare(any(byte[].class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/PdfCreatorTest.java
@@ -69,19 +69,16 @@ public class PdfCreatorTest {
         byte[] pdfContent = pdfCreator.createFromTemplates(docs);
 
         // then
-        InputStream actualPdfPage1 = getPdfPageContents(pdfContent, 0);
-        InputStream actualPdfPage2 = getPdfPageContents(pdfContent, 1);
+        try (
+            InputStream actualPdfPage1 = getPdfPageContents(pdfContent, 0);
+            InputStream actualPdfPage2 = getPdfPageContents(pdfContent, 1);
 
-        InputStream expectedPdfPage1 = getPdfPageContents(expectedMergedPdf, 0);
-        InputStream expectedPdfPage2 = getPdfPageContents(expectedMergedPdf, 1);
-
-        assertThat(actualPdfPage1).hasSameContentAs(expectedPdfPage1);
-        assertThat(actualPdfPage2).hasSameContentAs(expectedPdfPage2);
-
-        actualPdfPage1.close();
-        actualPdfPage2.close();
-        expectedPdfPage1.close();
-        expectedPdfPage2.close();
+            InputStream expectedPdfPage1 = getPdfPageContents(expectedMergedPdf, 0);
+            InputStream expectedPdfPage2 = getPdfPageContents(expectedMergedPdf, 1)
+        ) {
+            assertThat(actualPdfPage1).hasSameContentAs(expectedPdfPage1);
+            assertThat(actualPdfPage2).hasSameContentAs(expectedPdfPage2);
+        }
 
         // and
         verify(duplexPreparator, times(2)).prepare(any(byte[].class));


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Implement AKS for send letter service](https://tools.hmcts.net/jira/browse/BPS-399)

### Change description ###

Necessary changes to make AKS pass

- flyway strategy config used but not implemented
- private key is not interpreted as valid one
- java app correctness: close open input streams

last one is labelled as boy-scout one

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
