### PR TITLE
Replace `Timestamp`s with `LocalDateTime`s

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
@@ -18,7 +18,8 @@ import uk.gov.hmcts.reform.sendletter.SampleData;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
@@ -81,7 +82,7 @@ public class GetLetterStatusTest {
         );
     }
 
-    private String toIso(Timestamp timestamp) {
-        return DateTimeFormatter.ISO_INSTANT.format(timestamp.toInstant());
+    private String toIso(LocalDateTime dateTime) {
+        return dateTime.atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_INSTANT);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTaskTest.java
@@ -15,12 +15,10 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -125,7 +123,7 @@ public class StaleLettersTaskTest {
         // given
         Letter letter = createLetterWithSentToPrintTime(secondBeforeCutOff);
         letter.setStatus(LetterStatus.Posted);
-        letter.setPrintedAt(Timestamp.from(Instant.now()));
+        letter.setPrintedAt(now());
 
         // when
         repository.save(letter);
@@ -144,16 +142,14 @@ public class StaleLettersTaskTest {
             type,
             null,
             false,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
 
         if (sentToPrintAtTime != null) {
             letter.setStatus(LetterStatus.Uploaded);
-            letter.setSentToPrintAt(
-                Timestamp.valueOf(LocalDateTime.now()
-                    .minusDays(1)
-                    .with(sentToPrintAtTime)
-                )
+            letter.setSentToPrintAt(now()
+                .minusDays(1)
+                .with(sentToPrintAtTime)
             );
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Letter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Letter.java
@@ -6,7 +6,7 @@ import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -31,9 +31,9 @@ public class Letter {
     @Type(type = "json")
     @Column(columnDefinition = "json")
     private JsonNode additionalData;
-    private Timestamp createdAt;
-    private Timestamp sentToPrintAt;
-    private Timestamp printedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime sentToPrintAt;
+    private LocalDateTime printedAt;
     private boolean isFailed;
     private String type;
     @Enumerated(EnumType.STRING)
@@ -53,7 +53,7 @@ public class Letter {
         String type,
         byte[] fileContent,
         Boolean isEncrypted,
-        Timestamp createdAt
+        LocalDateTime createdAt
     ) {
         this.id = id;
         this.checksum = checksum;
@@ -98,23 +98,23 @@ public class Letter {
         this.fileContent = fileContent;
     }
 
-    public Timestamp getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public Timestamp getSentToPrintAt() {
+    public LocalDateTime getSentToPrintAt() {
         return sentToPrintAt;
     }
 
-    public void setSentToPrintAt(Timestamp value) {
+    public void setSentToPrintAt(LocalDateTime value) {
         this.sentToPrintAt = value;
     }
 
-    public Timestamp getPrintedAt() {
+    public LocalDateTime getPrintedAt() {
         return printedAt;
     }
 
-    public void setPrintedAt(Timestamp value) {
+    public void setPrintedAt(LocalDateTime value) {
         this.printedAt = value;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,7 +22,7 @@ public interface LetterRepository extends JpaRepository<Letter, UUID> {
         + "' and l.sentToPrintAt < :before")
     Stream<Letter> findByStatusAndSentToPrintAtBefore(
         @Param("status") LetterStatus status,
-        @Param("before") Timestamp before
+        @Param("before") LocalDateTime before
     );
 
     Optional<Letter> findByChecksumAndStatusOrderByCreatedAtDesc(String checksum, LetterStatus status);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
@@ -9,8 +9,6 @@ import uk.gov.hmcts.reform.logging.appinsights.AbstractAppInsights;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.model.ParsedReport;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,15 +50,14 @@ public class AppInsights extends AbstractAppInsights {
     // events
 
     public void trackStaleLetter(Letter staleLetter) {
-        LocalDateTime sentToPrint = LocalDateTime.ofInstant(staleLetter.getSentToPrintAt().toInstant(), ZoneOffset.UTC);
         Map<String, String> properties = new HashMap<>();
 
         properties.put("letterId", staleLetter.getId().toString());
         properties.put("checksum", staleLetter.getChecksum());
         properties.put("service", staleLetter.getService());
         properties.put("type", staleLetter.getType());
-        properties.put("sentToPrintDayOfWeek", sentToPrint.getDayOfWeek().name());
-        properties.put("sentToPrintAt", sentToPrint.format(TIME_FORMAT));
+        properties.put("sentToPrintDayOfWeek", staleLetter.getSentToPrintAt().getDayOfWeek().name());
+        properties.put("sentToPrintAt", staleLetter.getSentToPrintAt().format(TIME_FORMAT));
 
         telemetry.trackEvent(LETTER_NOT_PRINTED, properties, null);
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.reform.sendletter.services.util.FileNameHelper;
 import uk.gov.hmcts.reform.sendletter.services.util.FinalPackageFileNameHelper;
 import uk.gov.hmcts.reform.sendletter.services.zip.Zipper;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -107,7 +106,7 @@ public class LetterService {
             letter.getType(),
             zipContent,
             isEncryptionEnabled,
-            Timestamp.valueOf(createdAtTime)
+            createdAtTime
         );
 
         if (isEncryptionEnabled) {
@@ -176,10 +175,11 @@ public class LetterService {
             .orElseThrow(() -> new LetterNotFoundException(id));
     }
 
-    public static ZonedDateTime toDateTime(Timestamp stamp) {
-        if (null == stamp) {
+    static ZonedDateTime toDateTime(LocalDateTime dateTime) {
+        if (null == dateTime) {
             return null;
         }
-        return stamp.toInstant().atZone(ZoneId.of("UTC"));
+
+        return dateTime.atZone(ZoneId.of("UTC"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FinalPackageFileNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FinalPackageFileNameHelper.java
@@ -17,7 +17,7 @@ public final class FinalPackageFileNameHelper {
         return generateName(
             letter.getType(),
             letter.getService(),
-            letter.getCreatedAt().toLocalDateTime(),
+            letter.getCreatedAt(),
             letter.getId(),
             letter.isEncrypted()
         );

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.sendletter.services.ReportParser;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
-import java.sql.Timestamp;
 import java.time.LocalTime;
 import java.util.Optional;
 
@@ -88,7 +87,7 @@ public class MarkLettersPostedTask {
         if (optional.isPresent()) {
             Letter letter = optional.get();
             if (letter.getStatus() == LetterStatus.Uploaded) {
-                letter.setPrintedAt(Timestamp.from(letterPrintStatus.printedAt.toInstant()));
+                letter.setPrintedAt(letterPrintStatus.printedAt.toLocalDateTime());
                 letter.setStatus(LetterStatus.Posted);
                 repo.save(letter);
                 logger.info("Marked letter {} as posted", letter.getId());

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.stream.Stream;
@@ -45,11 +44,9 @@ public class StaleLettersTask {
     @SchedulerLock(name = TASK_NAME)
     @Scheduled(cron = "${tasks.stale-letters-report}")
     public void run() {
-        Timestamp staleCutOff = Timestamp.valueOf(
-            LocalDateTime.now()
-                .minusDays(1)
-                .with(staleCutOffTime)
-        );
+        LocalDateTime staleCutOff = LocalDateTime.now()
+            .minusDays(1)
+            .with(staleCutOffTime);
 
         logger.info("Started '{}' task with cut-off of {}", TASK_NAME, staleCutOff);
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -16,8 +16,6 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 import uk.gov.hmcts.reform.sendletter.services.util.FinalPackageFileNameHelper;
 
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -107,7 +105,7 @@ public class UploadLettersTask {
 
     private void markAsUploaded(Letter letter) {
         letter.setStatus(LetterStatus.Uploaded);
-        letter.setSentToPrintAt(Timestamp.from(Instant.now()));
+        letter.setSentToPrintAt(now());
 
         // remove pdf content, as it's no longer needed
         letter.setFileContent(null);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/SampleData.java
@@ -11,8 +11,6 @@ import uk.gov.hmcts.reform.sendletter.model.in.LetterRequest;
 import uk.gov.hmcts.reform.sendletter.model.in.LetterWithPdfsRequest;
 
 import java.io.IOException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Base64;
@@ -21,6 +19,7 @@ import java.util.UUID;
 
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.LocalDateTime.now;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
@@ -66,7 +65,7 @@ public final class SampleData {
                 "a type",
                 new byte[1],
                 false,
-                Timestamp.valueOf(LocalDateTime.now())
+                now()
             );
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
@@ -16,10 +16,8 @@ import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.model.LetterPrintStatus;
 import uk.gov.hmcts.reform.sendletter.model.ParsedReport;
 
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -140,11 +139,11 @@ public class AppInsightsTest {
             TYPE,
             null,
             false,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
 
-        ZonedDateTime sentToPrint = ZonedDateTime.now(ZoneOffset.UTC);
-        letter.setSentToPrintAt(Timestamp.from(sentToPrint.toInstant()));
+        LocalDateTime sentToPrint = now();
+        letter.setSentToPrintAt(sentToPrint);
 
         insights.trackStaleLetter(letter);
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FinalPackageFileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FinalPackageFileNameHelperTest.java
@@ -4,10 +4,9 @@ import org.junit.Test;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.services.util.FinalPackageFileNameHelper;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
+import static java.time.LocalDateTime.now;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,10 +23,8 @@ public class FinalPackageFileNameHelperTest {
             "type",
             null,
             false,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
-
-        LocalDateTime createdAt = letter.getCreatedAt().toLocalDateTime();
 
         // when
         String name = FinalPackageFileNameHelper.generateName(letter);
@@ -35,7 +32,7 @@ public class FinalPackageFileNameHelperTest {
         // then
         assertThat(name).isEqualTo(
             "type_cmc_"
-                + createdAt.format(FinalPackageFileNameHelper.dateTimeFormatter)
+                + letter.getCreatedAt().format(FinalPackageFileNameHelper.dateTimeFormatter)
                 + "_"
                 + letter.getId()
                 + ".zip"
@@ -44,14 +41,13 @@ public class FinalPackageFileNameHelperTest {
 
     @Test
     public void should_generate_expected_file_name_with_explicit_parameters_as_input() {
-        LocalDateTime createdAt = LocalDateTime.now();
         UUID letterId = randomUUID();
 
-        String name = FinalPackageFileNameHelper.generateName("type", "cmc", LocalDateTime.now(), letterId,true);
+        String name = FinalPackageFileNameHelper.generateName("type", "cmc", now(), letterId,true);
 
         assertThat(name).isEqualTo(
             "type_cmc_"
-                + createdAt.format(FinalPackageFileNameHelper.dateTimeFormatter)
+                + now().format(FinalPackageFileNameHelper.dateTimeFormatter)
                 + "_"
                 + letterId
                 + ".pgp"
@@ -69,7 +65,7 @@ public class FinalPackageFileNameHelperTest {
             "type",
             null,
             false,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
 
         // when
@@ -90,7 +86,7 @@ public class FinalPackageFileNameHelperTest {
             "some_type",
             null,
             false,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
 
         // when
@@ -110,7 +106,7 @@ public class FinalPackageFileNameHelperTest {
             "type",
             null,
             false,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
 
         Letter encryptedLetter = new Letter(
@@ -121,7 +117,7 @@ public class FinalPackageFileNameHelperTest {
             "type",
             null,
             true,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
 
         assertThat(FinalPackageFileNameHelper.generateName(zippedLetter)).endsWith(".zip");

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -14,13 +14,12 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
+import static java.time.LocalDateTime.now;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -113,7 +112,7 @@ public class UploadLettersTaskTest {
             type,
             "hello".getBytes(),
             true,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
     }
 
@@ -126,7 +125,7 @@ public class UploadLettersTaskTest {
             "type",
             "hello".getBytes(),
             true,
-            Timestamp.valueOf(LocalDateTime.now())
+            now()
         );
     }
 


### PR DESCRIPTION
### Change description ###

You can magically hit the spot and fail integration test due to indifference between `Timestamp` and `LocalDateTime`/`ZonedDateTime` implementations. Here are examples:
- [dependency bump](https://build.platform.hmcts.net/view/BSP/job/HMCTS_Platform/job/send-letter-service/view/change-requests/job/PR-305/5/)
- [docker image fix](https://build.platform.hmcts.net/view/BSP/job/HMCTS_Platform/job/send-letter-service/view/change-requests/job/PR-307/2)

This hopefully solves the matter

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
