### PR TITLE
Use previous page size for extra blank page

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/pdf/DuplexPreparator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/pdf/DuplexPreparator.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sendletter.services.pdf;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.exception.DuplexException;
 
@@ -17,7 +18,8 @@ public class DuplexPreparator {
     public byte[] prepare(byte[] pdf) {
         try (PDDocument pdDoc = PDDocument.load(pdf)) {
             if (pdDoc.getNumberOfPages() % 2 == 1) {
-                pdDoc.addPage(new PDPage());
+                PDRectangle lastPageMediaBox = pdDoc.getPage(pdDoc.getNumberOfPages() -1 ).getMediaBox();
+                pdDoc.addPage(new PDPage(lastPageMediaBox));
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 pdDoc.save(out);
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/pdf/DuplexPreparator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/pdf/DuplexPreparator.java
@@ -18,7 +18,7 @@ public class DuplexPreparator {
     public byte[] prepare(byte[] pdf) {
         try (PDDocument pdDoc = PDDocument.load(pdf)) {
             if (pdDoc.getNumberOfPages() % 2 == 1) {
-                PDRectangle lastPageMediaBox = pdDoc.getPage(pdDoc.getNumberOfPages() -1 ).getMediaBox();
+                PDRectangle lastPageMediaBox = pdDoc.getPage(pdDoc.getNumberOfPages() - 1).getMediaBox();
                 pdDoc.addPage(new PDPage(lastPageMediaBox));
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 pdDoc.save(out);


### PR DESCRIPTION
It used to default to U.S. Letter, 8.5" x 11".

This was OK for pdfs that we generate based on template that service send us, but there is also a new endpoint that accepts pdf (which may use different sizing).