### PR TITLE
Derive ase name from core compute environment

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_resource_group" "rg" {
 }
 
 locals {
-  ase_name               = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  ase_name               = "core-compute-${var.env}"
 
   ftp_private_key        = "${data.azurerm_key_vault_secret.ftp_private_key.value}"
   ftp_public_key         = "${data.azurerm_key_vault_secret.ftp_public_key.value}"


### PR DESCRIPTION
- Working build with the change https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_Platform/job/send-letter-service/job/FIX-SPROD/20/

- Using remote state results into below error for prod
```
11:32:10 Error: Error running plan: 1 error(s) occurred:

11:32:10 * local.ase_name: local.ase_name: Resource 'data.terraform_remote_state.core_apps_compute' does not have attribute 'ase_name' for variable 'data.terraform_remote_state.core_apps_compute.ase_name'

```