### PR TITLE
Update checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ task smoke(type: Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '8.10.1'
+  toolVersion = '8.18'
   // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
   configDir = new File(rootDir, 'config/checkstyle')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ checkstyle {
 }
 
 pmd {
-  toolVersion = "6.5.0"
+  toolVersion = "6.12.0"
   ignoreFailures = true
   sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
   reportsDir = file("$project.buildDir/reports/pmd")

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -21,7 +21,12 @@
   <property name="severity" value="warning"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
-  <!-- Checks for whitespace                               -->
+  <!-- Excludes all 'module-info.java' files        -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+  <!-- Checks for whitespace                 -->
   <!-- See http://checkstyle.sf.net/config_whitespace.html -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
@@ -74,6 +79,7 @@
     </module>
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
       <property name="allowEmptyMethods" value="true"/>
       <property name="allowEmptyTypes" value="true"/>
       <property name="allowEmptyLoops" value="true"/>
@@ -137,6 +143,11 @@
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
                value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -34,11 +34,6 @@
       <property name="minimum" value="2" />
     </properties>
   </rule>
-  <rule ref="category/java/codestyle.xml/VariableNamingConventions">
-    <properties>
-      <property name="violationSuppressRegex" value=".*'log'.*" />
-    </properties>
-  </rule>
   <rule ref="category/java/design.xml">
     <exclude name="AvoidCatchingGenericException" />
     <exclude name="UseUtilityClass" />


### PR DESCRIPTION
### Change description ###

Updating to latest toolset. Note: `VariableNamingConventions` is becoming unsupported from pmd v7 so removing now as per warning

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
