### PR TITLE
Bump pdfbox 2.0.14 -> 2.0.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ def versions = [
   flywayV: plugins.getPlugin('org.flywaydb.flyway').class.package.implementationVersion,
   junit: '5.4.1',
   mockitoJupiter: '2.25.1',
-  pdfbox: '2.0.14',
+  pdfbox: '2.0.15',
   reformLogging: '5.0.1',
   restAssured: '3.3.0',
   shedlock: '2.4.0',


### PR DESCRIPTION
### Change description ###

New vulnerability for XXE attacks [discovered](https://nvd.nist.gov/vuln/detail/CVE-2019-0228). There's next bugfix version available which is not under owasp radar at the moment

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
