### PR TITLE
Use `Europe/London` timezone in tasks

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/DeleteOldFilesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/DeleteOldFilesTask.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static java.time.Instant.now;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 /**
  * Deletes old files from SFTP.
@@ -46,7 +47,7 @@ public class DeleteOldFilesTask {
     // endregion
 
     @SchedulerLock(name = TASK_NAME)
-    @Scheduled(cron = "${file-cleanup.cron}")
+    @Scheduled(cron = "${file-cleanup.cron}", zone = EUROPE_LONDON)
     public void run() {
         serviceFolderMapping
             .getFolders()

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
@@ -17,7 +17,10 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Optional;
+
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 /**
  * Fetches reports from SFTP concerning posted
@@ -51,9 +54,9 @@ public class MarkLettersPostedTask {
     }
 
     @SchedulerLock(name = TASK_NAME)
-    @Scheduled(cron = "${tasks.mark-letters-posted}")
+    @Scheduled(cron = "${tasks.mark-letters-posted}", zone = EUROPE_LONDON)
     public void run() {
-        if (!ftpAvailabilityChecker.isFtpAvailable(LocalTime.now())) {
+        if (!ftpAvailabilityChecker.isFtpAvailable(LocalTime.now(ZoneId.of(EUROPE_LONDON)))) {
             logger.info("Not processing '{}' task due to FTP downtime window", TASK_NAME);
             return;
         }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
@@ -17,6 +17,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.stream.Stream;
 
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
+
 /**
  * Task to run report on unprinted letters and report them to AppInsights.
  */
@@ -42,7 +44,7 @@ public class StaleLettersTask {
 
     @Transactional
     @SchedulerLock(name = TASK_NAME)
-    @Scheduled(cron = "${tasks.stale-letters-report}")
+    @Scheduled(cron = "${tasks.stale-letters-report}", zone = EUROPE_LONDON)
     public void run() {
         LocalDateTime staleCutOff = LocalDateTime.now()
             .minusDays(1)

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -16,11 +16,13 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 import uk.gov.hmcts.reform.sendletter.services.util.FinalPackageFileNameHelper;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import static java.time.LocalDateTime.now;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 @Component
 @ConditionalOnProperty(value = "scheduling.enabled", matchIfMissing = true)
@@ -52,7 +54,7 @@ public class UploadLettersTask {
     @SchedulerLock(name = TASK_NAME)
     @Scheduled(fixedDelayString = "${tasks.upload-letters-interval-ms}")
     public void run() {
-        if (!availabilityChecker.isFtpAvailable(now().toLocalTime())) {
+        if (!availabilityChecker.isFtpAvailable(now(ZoneId.of(EUROPE_LONDON)).toLocalTime())) {
             logger.info("Not processing '{}' task due to FTP downtime window", TASK_NAME);
             return;
         }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/util/TimeZones.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/util/TimeZones.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.sendletter.util;
+
+public final class TimeZones {
+
+    public static final String EUROPE_LONDON = "Europe/London";
+
+    private TimeZones() {
+        // utility class construct
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,7 +52,7 @@ ftp:
   privateKey: ${FTP_PRIVATE_KEY}
   publicKey: ${FTP_PUBLIC_KEY}
   downtime:
-    from: ${FTP_DOWNTIME_FROM:15:00}
+    from: ${FTP_DOWNTIME_FROM:16:00}
     to: ${FTP_DOWNTIME_TO:17:00}
   service-folders:
     - service: cmc_claim_store


### PR DESCRIPTION
### Change description ###

Depending what date it is `Europe/London` fluctuates between **GMT** and **BST**. Attaching zone ids to cron tasks and to ftp availability checks

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
