### PR TITLE
Update configuration for RestTemplate

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/RestTemplateConfiguration.java
@@ -1,7 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -9,9 +10,6 @@ import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfiguration {
-
-    @Autowired
-    private CloseableHttpClient httpClient;
 
     @Bean
     public RestTemplate restTemplate() {
@@ -22,8 +20,22 @@ public class RestTemplateConfiguration {
     public HttpComponentsClientHttpRequestFactory clientHttpRequestFactory() {
         HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
 
-        clientHttpRequestFactory.setHttpClient(httpClient);
+        clientHttpRequestFactory.setHttpClient(getHttpClient());
 
         return clientHttpRequestFactory;
+    }
+
+    private CloseableHttpClient getHttpClient() {
+        RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(30000)
+            .setConnectionRequestTimeout(30000)
+            .setSocketTimeout(60000)
+            .build();
+
+        return HttpClientBuilder
+            .create()
+            .useSystemProperties()
+            .setDefaultRequestConfig(config)
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/RestTemplateConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sendletter.config;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    @Autowired
+    private CloseableHttpClient httpClient;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate(clientHttpRequestFactory());
+    }
+
+    @Bean
+    public HttpComponentsClientHttpRequestFactory clientHttpRequestFactory() {
+        HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
+
+        clientHttpRequestFactory.setHttpClient(httpClient);
+
+        return clientHttpRequestFactory;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/ThreadPoolConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/ThreadPoolConfig.java
@@ -12,8 +12,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @Configuration
 public class ThreadPoolConfig {
 
-    static int errorCount;
-    static final Logger log = LoggerFactory.getLogger(ThreadPoolConfig.class);
+    private static int errorCount;
+    private static final Logger log = LoggerFactory.getLogger(ThreadPoolConfig.class);
 
     public static int getUnhandledTaskExceptionCount() {
         return errorCount;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ idam:
 
 spring:
   application:
-    name: Send Letter Provider
+    name: Send Letter Service
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${LETTER_TRACKING_DB_HOST:send-letter-database}:${LETTER_TRACKING_DB_PORT:5432}/${LETTER_TRACKING_DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}


### PR DESCRIPTION
### Change description ###

Following [suggestion](https://howtodoinjava.com/spring-restful/resttemplate-httpclient-java-config/) and the fact that app insights tracks http calls made only via apache http, this configuration should provide such functionality

Couple bonus commits just to drag in some super minor amendments

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
