### PR TITLE
Improving try/catch block accompanying exception message

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/config/SftpConfig.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/config/SftpConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import uk.gov.hmcts.reform.sendletter.helper.FakeFtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
+import uk.gov.hmcts.reform.sendletter.services.ftp.SshClient;
 
 import java.util.function.Supplier;
 
@@ -18,7 +19,7 @@ public class SftpConfig {
         // Provide clients that do not verify
         // host name and key for local testing.
         return () -> {
-            SSHClient client = new SSHClient();
+            SSHClient client = new SshClient();
             client.addHostKeyVerifier((a, b, c) -> true);
             return client;
         };

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/SftpConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/SftpConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
+import uk.gov.hmcts.reform.sendletter.services.ftp.SshClient;
 
 import java.util.function.Supplier;
 
@@ -14,7 +15,7 @@ public class SftpConfig {
 
     @Bean
     public Supplier<SSHClient> sshClient() {
-        return SSHClient::new;
+        return SshClient::new;
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.sendletter.model.Report;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
@@ -179,23 +178,12 @@ public class FtpClient {
                 return action.apply(sftp);
             }
         } catch (IOException exc) {
-            throw new FtpException(
-                String.format("Unable to execute command %s.", getCallerName(exc)),
-                exc
-            );
+            throw new FtpException("Unable to execute command", exc);
         }
     }
 
     private boolean isReportFile(RemoteResourceInfo resourceInfo) {
         return resourceInfo.isRegularFile()
             && resourceInfo.getName().toLowerCase(Locale.getDefault()).endsWith(".csv");
-    }
-
-    private String getCallerName(Exception exception) {
-        return Arrays.stream(exception.getStackTrace())
-            .skip(1) // first one should be `runWith`
-            .findFirst()
-            .map(StackTraceElement::getMethodName)
-            .orElse("UnknownMethodName");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -161,7 +161,7 @@ public class FtpClient {
         runWith(sftpClient -> null);
     }
 
-    private <T> T runWith(Function<SFTPClient, T> action) {
+    <T> T runWith(Function<SFTPClient, T> action) {
         try (SSHClient ssh = sshClientSupplier.get()) {
             ssh.addHostKeyVerifier(configProperties.getFingerprint());
             ssh.connect(configProperties.getHostname(), configProperties.getPort());

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/SshClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/SshClient.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 
 /**
  * Class to manage {@link SSHClient} with current state of service.
- *
  * For backwards compatibility the overridden {@link SshClient#close()}
  * is written to mimic previous pseudo-complex usage in {@link FtpClient#runWith(Function)}
  */

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/SshClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/SshClient.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.sendletter.services.ftp;
+
+import net.schmizz.sshj.SSHClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * Class to manage {@link SSHClient} with current state of service.
+ *
+ * For backwards compatibility the overridden {@link SshClient#close()}
+ * is written to mimic previous pseudo-complex usage in {@link FtpClient#runWith(Function)}
+ */
+public class SshClient extends SSHClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(SshClient.class);
+
+    public SshClient() {
+        super();
+    }
+
+    @Override
+    public void close() {
+        try {
+            super.close();
+        } catch (IOException exception) {
+            logger.warn("Error closing ssh connection.", exception);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
@@ -167,6 +167,6 @@ class FtpClientTest {
         // then
         assertThat(exception)
             .isInstanceOf(FtpException.class)
-            .hasMessage("Unable to execute command testConnection.");
+            .hasMessage("Unable to execute command");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/FtpClientTest.java
@@ -31,6 +31,7 @@ import static org.mockito.BDDMockito.doNothing;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,7 +80,9 @@ class FtpClientTest {
         Throwable exception = catchThrowable(() -> client.downloadReports());
 
         // then
-        assertThat(exception).isInstanceOf(FtpException.class);
+        assertThat(exception)
+            .isInstanceOf(FtpException.class)
+            .hasMessage("Error while downloading reports");
     }
 
     @Test
@@ -121,7 +124,9 @@ class FtpClientTest {
         );
 
         // then
-        assertThat(exception).isInstanceOf(FtpException.class);
+        assertThat(exception)
+            .isInstanceOf(FtpException.class)
+            .hasMessage("Unable to upload file.");
     }
 
     @Test
@@ -145,6 +150,23 @@ class FtpClientTest {
         Throwable exception = catchThrowable(() -> client.deleteReport("some/report"));
 
         // then
-        assertThat(exception).isInstanceOf(FtpException.class);
+        assertThat(exception)
+            .isInstanceOf(FtpException.class)
+            .hasMessage("Error while deleting report: some/report");
+    }
+
+    @Test
+    void should_not_apply_action_if_IoException_is_during_sftp_setup() throws IOException {
+        // given
+        reset(sshClient);
+        willThrow(new IOException("oh no")).given(sshClient).newSFTPClient();
+
+        // when
+        Throwable exception = catchThrowable(() -> client.testConnection());
+
+        // then
+        assertThat(exception)
+            .isInstanceOf(FtpException.class)
+            .hasMessage("Unable to execute command testConnection.");
     }
 }


### PR DESCRIPTION
### Change description ###

`SSHClient` is of `Closeable` interface so can be entirely moved to _try with resources_. Also fixing exception message. Apologies for not splitting this into separate commit

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
