### PR TITLE
Include `ApacheHttpClient` for feign connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,8 @@ dependencies {
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.1.RELEASE'
 
+  compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '10.2.0'
+
   compile group: 'com.hierynomus', name: 'sshj', version: '0.27.0'
   compile group: 'org.apache.pdfbox', name: 'pdfbox', version: versions.pdfbox
   compile group: 'org.apache.commons', name: 'commons-csv', version: '1.6'

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/RestTemplateConfiguration.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
+import feign.Client;
+import feign.httpclient.ApacheHttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -12,17 +14,18 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfiguration {
 
     @Bean
+    public Client getFeignHttpClient() {
+        return new ApacheHttpClient(getHttpClient());
+    }
+
+    @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate(clientHttpRequestFactory());
     }
 
     @Bean
     public HttpComponentsClientHttpRequestFactory clientHttpRequestFactory() {
-        HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
-
-        clientHttpRequestFactory.setHttpClient(getHttpClient());
-
-        return clientHttpRequestFactory;
+        return new HttpComponentsClientHttpRequestFactory(getHttpClient());
     }
 
     private CloseableHttpClient getHttpClient() {


### PR DESCRIPTION
### Change description ###

Additional bean for `feign.Client` is apparently required for application insights' agent. Purposefully skipped during #369 😞 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
