### PR TITLE
Fix AKS pipeline for PRs

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -40,7 +40,7 @@ withPipeline(type , product, component) {
       env.FTP_TARGET_FOLDER = 'TO_XEROX'
       env.TEST_FTP_REPORTS_FOLDER = 'FROM_XEROX'
       env.TEST_ENCRYPTION_ENABLED = false
-      env.RESOURCE_GROUP = "${product}-${component}-aks"
+//      env.RESOURCE_GROUP = "${product}-${component}-aks"
     }
   }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -40,7 +40,6 @@ withPipeline(type , product, component) {
       env.FTP_TARGET_FOLDER = 'TO_XEROX'
       env.TEST_FTP_REPORTS_FOLDER = 'FROM_XEROX'
       env.TEST_ENCRYPTION_ENABLED = false
-//      env.RESOURCE_GROUP = "${product}-${component}-aks"
     }
   }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -29,7 +29,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 GradleBuilder builder = new GradleBuilder(this, product)
 
 withPipeline(type , product, component) {
-  before('smoketest:aks') {
+  before('smoketest:preview') {
     withAksClient('nonprod') {
       // vars needed for AKS testing
       env.TEST_S2S_NAME = 'send_letter_tests'


### PR DESCRIPTION
### Change description ###

By tracking/scrolling through this hmcts/cnp-jenkins-library#465 looks like `$environment` is used which is `preview` (checking pipeline in jenkins).

Since PRs installed AKS anyway, ~commenting out~ removing `RESOURCE_GROUP` ~to test hypothesis of~ as it ~being~ become obsolete

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
