### PR TITLE
Add service layer for the letters count report

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportsService.java
@@ -10,13 +10,11 @@ import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.localDateTimeWithUtc;
 
 @Service
 public class ReportsService {
@@ -48,8 +46,8 @@ public class ReportsService {
     }
 
     public List<LettersCountSummary> getCountFor(LocalDate date) {
-        LocalDateTime dateTimeFrom = formatDateTime(date.minusDays(1), LocalTime.parse(timeFromHour));
-        LocalDateTime dateTimeTo = formatDateTime(date, LocalTime.parse(timeToHour));
+        LocalDateTime dateTimeFrom = localDateTimeWithUtc(date.minusDays(1), LocalTime.parse(timeFromHour));
+        LocalDateTime dateTimeTo = localDateTimeWithUtc(date, LocalTime.parse(timeToHour));
 
         return zeroRowFiller.fill(
             repo.countByDate(dateTimeFrom, dateTimeTo).stream().map(this::fromDb).collect(toList()))
@@ -64,10 +62,5 @@ public class ReportsService {
         return new LettersCountSummary(
             serviceFolderMapping.getFolderFor(dbSummary.getService()).orElse(null),
             dbSummary.getUploaded());
-    }
-
-    private LocalDateTime formatDateTime(LocalDate date, LocalTime time) {
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.from(ZoneOffset.UTC));
-        return zonedDateTime.toLocalDateTime();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportsService.java
@@ -1,16 +1,63 @@
 package uk.gov.hmcts.reform.sendletter.services;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sendletter.entity.LettersCountSummaryRepository;
+import uk.gov.hmcts.reform.sendletter.entity.reports.ServiceLettersCountSummary;
 import uk.gov.hmcts.reform.sendletter.model.out.LettersCountSummary;
+import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 @Service
 public class ReportsService {
 
+    private static final String TEST_SERVICE = "BULKPRINT";
+
+    private final LettersCountSummaryRepository repo;
+
+    private final ServiceFolderMapping serviceFolderMapping;
+
+    private final ZeroRowFiller zeroRowFiller;
+
+    public ReportsService(
+        LettersCountSummaryRepository repo,
+        ServiceFolderMapping serviceFolderMapping,
+        ZeroRowFiller zeroRowFiller
+    ) {
+        this.repo = repo;
+        this.serviceFolderMapping = serviceFolderMapping;
+        this.zeroRowFiller = zeroRowFiller;
+    }
+
     public List<LettersCountSummary> getCountFor(LocalDate date) {
-        throw new NotImplementedException("Not yet implemented");
+        LocalDateTime dateTimeFrom = formatDateTime(date.minusDays(1), LocalTime.of(17, 0, 0));
+        LocalDateTime dateTimeTo = formatDateTime(date, LocalTime.of(16, 0, 0));
+
+        return zeroRowFiller.fill(
+            repo.countByDate(dateTimeFrom, dateTimeTo).stream().map(this::fromDb).collect(toList()))
+            .stream()
+            .filter(summary -> !summary.service.equals(TEST_SERVICE))
+            .collect(toList()); //exclude test service
+    }
+
+    private LettersCountSummary fromDb(ServiceLettersCountSummary dbSummary) {
+        return new LettersCountSummary(
+            serviceFolderMapping.getFolderFor(dbSummary.getService()).orElse(null),
+            dbSummary.getUploaded());
+    }
+
+    private LocalDateTime formatDateTime(LocalDate date, LocalTime time) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.of(EUROPE_LONDON));
+        String formattedDateTime = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        return LocalDateTime.parse(formattedDateTime);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ZeroRowFiller.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ZeroRowFiller.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.sendletter.services;
+
+import com.google.common.collect.Sets;
+import org.assertj.core.util.Lists;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sendletter.model.out.LettersCountSummary;
+import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+@Component
+public class ZeroRowFiller {
+
+    private final List<String> serviceFolders;
+
+    private final ServiceFolderMapping serviceFolderMapping;
+
+    public ZeroRowFiller(ServiceFolderMapping serviceFolderMapping) {
+        this.serviceFolderMapping = serviceFolderMapping;
+        this.serviceFolders = Lists.newArrayList(serviceFolderMapping.getFolders());
+    }
+
+    public List<LettersCountSummary> fill(List<LettersCountSummary> listToFill) {
+        return Stream.concat(
+            listToFill.stream(),
+            missingServiceFolders(listToFill).stream().map(
+                serviceFolder -> new LettersCountSummary(serviceFolder, 0)
+            )
+        ).collect(toList());
+    }
+
+    private Set<String> missingServiceFolders(List<LettersCountSummary> listToFill) {
+        return Sets.difference(
+            Sets.newHashSet(this.serviceFolders),
+            listToFill.stream().map(res -> res.service).collect(toSet())
+        );
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ZeroRowFiller.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ZeroRowFiller.java
@@ -18,10 +18,7 @@ public class ZeroRowFiller {
 
     private final List<String> serviceFolders;
 
-    private final ServiceFolderMapping serviceFolderMapping;
-
     public ZeroRowFiller(ServiceFolderMapping serviceFolderMapping) {
-        this.serviceFolderMapping = serviceFolderMapping;
         this.serviceFolders = Lists.newArrayList(serviceFolderMapping.getFolders());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/util/TimeZones.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/util/TimeZones.java
@@ -1,10 +1,22 @@
 package uk.gov.hmcts.reform.sendletter.util;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 public final class TimeZones {
 
     public static final String EUROPE_LONDON = "Europe/London";
 
     private TimeZones() {
         // utility class construct
+    }
+
+    public static LocalDateTime localDateTimeWithUtc(LocalDate date, LocalTime time) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.from(ZoneOffset.UTC));
+        return zonedDateTime.toLocalDateTime();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
@@ -11,11 +11,7 @@ import uk.gov.hmcts.reform.sendletter.model.out.LettersCountSummary;
 import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.localDateTimeWithUtc;
 
 @ExtendWith(MockitoExtension.class)
 class ReportsServiceTest {
@@ -55,14 +52,16 @@ class ReportsServiceTest {
         LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
-        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
-            .willReturn(asList(
-                new ServiceLettersCount("aService", 10),
-                new ServiceLettersCount("bService", 20)
-            ));
+        given(repository.countByDate(
+            localDateTimeWithUtc(date.minusDays(1), timeFrom),
+            localDateTimeWithUtc(date, timeTo))
+        ).willReturn(asList(
+            new ServiceLettersCount("aService", 10),
+            new ServiceLettersCount("bService", 20)
+        ));
 
-        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("ServiceA"));
-        given(serviceFolderMapping.getFolderFor("bService")).willReturn(Optional.of("ServiceB"));
+        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("FolderA"));
+        given(serviceFolderMapping.getFolderFor("bService")).willReturn(Optional.of("FolderB"));
 
         //when
         List<LettersCountSummary> result = service.getCountFor(date);
@@ -73,8 +72,8 @@ class ReportsServiceTest {
             .hasSize(2)
             .usingFieldByFieldElementComparator()
             .containsExactlyInAnyOrder(
-                new LettersCountSummary("ServiceA", 10),
-                new LettersCountSummary("ServiceB", 20));
+                new LettersCountSummary("FolderA", 10),
+                new LettersCountSummary("FolderB", 20));
     }
 
     @Test
@@ -84,12 +83,14 @@ class ReportsServiceTest {
         LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
-        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
-            .willReturn(asList(
-                new ServiceLettersCount("aService", 10),
-                new ServiceLettersCount("send_letter_tests", 20)
-            ));
-        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("ServiceA"));
+        given(repository.countByDate(
+            localDateTimeWithUtc(date.minusDays(1), timeFrom),
+            localDateTimeWithUtc(date, timeTo))
+        ).willReturn(asList(
+            new ServiceLettersCount("aService", 10),
+            new ServiceLettersCount("send_letter_tests", 20)
+        ));
+        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("FolderA"));
         given(serviceFolderMapping.getFolderFor("send_letter_tests")).willReturn(Optional.of("BULKPRINT"));
 
         //when
@@ -99,7 +100,7 @@ class ReportsServiceTest {
         assertThat(result).isNotEmpty()
             .hasSize(1)
             .usingFieldByFieldElementComparator()
-            .containsExactlyInAnyOrder(new LettersCountSummary("ServiceA", 10));
+            .containsExactlyInAnyOrder(new LettersCountSummary("FolderA", 10));
     }
 
     @Test
@@ -109,12 +110,14 @@ class ReportsServiceTest {
         LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
-        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
-            .willReturn(asList(
-                new ServiceLettersCount("aService", 10),
-                new ServiceLettersCount(null, 2)
-            ));
-        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("ServiceA"));
+        given(repository.countByDate(
+            localDateTimeWithUtc(date.minusDays(1), timeFrom),
+            localDateTimeWithUtc(date, timeTo))
+        ).willReturn(asList(
+            new ServiceLettersCount("aService", 10),
+            new ServiceLettersCount(null, 2)
+        ));
+        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("FolderA"));
 
         //when
         List<LettersCountSummary> result = service.getCountFor(date);
@@ -123,7 +126,7 @@ class ReportsServiceTest {
         assertThat(result).isNotEmpty()
             .hasSize(1)
             .usingFieldByFieldElementComparator()
-            .containsExactlyInAnyOrder(new LettersCountSummary("ServiceA", 10));
+            .containsExactlyInAnyOrder(new LettersCountSummary("FolderA", 10));
     }
 
     @Test
@@ -133,19 +136,16 @@ class ReportsServiceTest {
         LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
-        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
-            .willReturn(Collections.emptyList());
+        given(repository.countByDate(
+            localDateTimeWithUtc(date.minusDays(1), timeFrom),
+            localDateTimeWithUtc(date, timeTo))
+        ).willReturn(Collections.emptyList());
 
         //when
         List<LettersCountSummary> result = service.getCountFor(date);
 
         //then
         assertThat(result).isEmpty();
-    }
-
-    private LocalDateTime formatDateTime(LocalDate date, LocalTime time) {
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.from(ZoneOffset.UTC));
-        return zonedDateTime.toLocalDateTime();
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
@@ -1,0 +1,129 @@
+package uk.gov.hmcts.reform.sendletter.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.sendletter.entity.LettersCountSummaryRepository;
+import uk.gov.hmcts.reform.sendletter.entity.reports.ServiceLettersCount;
+import uk.gov.hmcts.reform.sendletter.model.out.LettersCountSummary;
+import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
+
+@ExtendWith(MockitoExtension.class)
+class ReportsServiceTest {
+
+    @Mock
+    LettersCountSummaryRepository repository;
+
+    @Mock
+    private ZeroRowFiller zeroRowFiller;
+
+    @Mock
+    ServiceFolderMapping serviceFolderMapping;
+
+    private ReportsService service;
+
+    @BeforeEach
+    void setUp() {
+        this.service = new ReportsService(this.repository, serviceFolderMapping, zeroRowFiller);
+
+        when(this.zeroRowFiller.fill(any()))
+            .thenAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
+    }
+
+    @Test
+    void should_return_letters_count_for_the_date() {
+        LocalDate date = LocalDate.now();
+        LocalTime timeFrom = LocalTime.of(17, 0, 0);
+        LocalTime timeTo = LocalTime.of(16, 0, 0);
+
+        //given
+        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
+            .willReturn(asList(
+                new ServiceLettersCount("aService", 10),
+                new ServiceLettersCount("bService", 20)
+            ));
+
+        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("ServiceA"));
+        given(serviceFolderMapping.getFolderFor("bService")).willReturn(Optional.of("ServiceB"));
+
+        //when
+        List<LettersCountSummary> result = service.getCountFor(date);
+
+        //then
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(2)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new LettersCountSummary("ServiceA", 10),
+                new LettersCountSummary("ServiceB", 20));
+    }
+
+    @Test
+    void should_return_letters_count_excluding_the_test_service() {
+        LocalDate date = LocalDate.now();
+        LocalTime timeFrom = LocalTime.of(17, 0, 0);
+        LocalTime timeTo = LocalTime.of(16, 0, 0);
+
+        //given
+        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
+            .willReturn(asList(
+                new ServiceLettersCount("aService", 10),
+                new ServiceLettersCount("send_letter_tests", 20)
+            ));
+        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("ServiceA"));
+        given(serviceFolderMapping.getFolderFor("send_letter_tests")).willReturn(Optional.of("BULKPRINT"));
+
+        //when
+        List<LettersCountSummary> result = service.getCountFor(date);
+
+        //then
+        assertThat(result).isNotEmpty()
+            .hasSize(1)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(new LettersCountSummary("ServiceA", 10));
+    }
+
+    @Test
+    void should_return_empty_list_for_the_date_when_repo_returns_empty_collection() {
+        LocalDate date = LocalDate.now();
+        LocalTime timeFrom = LocalTime.of(17, 0, 0);
+        LocalTime timeTo = LocalTime.of(16, 0, 0);
+
+        //given
+        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
+            .willReturn(Collections.emptyList());
+
+        //when
+        List<LettersCountSummary> result = service.getCountFor(date);
+
+        //then
+        assertThat(result).isEmpty();
+    }
+
+    private LocalDateTime formatDateTime(LocalDate date, LocalTime time) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.of(EUROPE_LONDON));
+        String formattedDateTime = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        return LocalDateTime.parse(formattedDateTime);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
@@ -37,13 +37,13 @@ class ReportsServiceTest {
     private ZeroRowFiller zeroRowFiller;
 
     @Mock
-    ServiceFolderMapping serviceFolderMapping;
+    private ServiceFolderMapping serviceFolderMapping;
 
     private ReportsService service;
 
     @BeforeEach
     void setUp() {
-        this.service = new ReportsService(this.repository, serviceFolderMapping, zeroRowFiller);
+        this.service = new ReportsService(this.repository, serviceFolderMapping, zeroRowFiller, "17:00", "16:00");
 
         when(this.zeroRowFiller.fill(any()))
             .thenAnswer(invocation -> invocation.getArgument(0)); // return data unchanged

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/ReportsServiceTest.java
@@ -14,8 +14,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 @ExtendWith(MockitoExtension.class)
 class ReportsServiceTest {
@@ -43,7 +42,7 @@ class ReportsServiceTest {
 
     @BeforeEach
     void setUp() {
-        this.service = new ReportsService(this.repository, serviceFolderMapping, zeroRowFiller, "17:00", "16:00");
+        this.service = new ReportsService(this.repository, serviceFolderMapping, zeroRowFiller, "16:00", "17:00");
 
         when(this.zeroRowFiller.fill(any()))
             .thenAnswer(invocation -> invocation.getArgument(0)); // return data unchanged
@@ -51,9 +50,9 @@ class ReportsServiceTest {
 
     @Test
     void should_return_letters_count_for_the_date() {
-        LocalDate date = LocalDate.now();
-        LocalTime timeFrom = LocalTime.of(17, 0, 0);
-        LocalTime timeTo = LocalTime.of(16, 0, 0);
+        LocalDate date = LocalDate.of(2019, 4, 25);
+        LocalTime timeFrom = LocalTime.parse("17:00");
+        LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
         given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
@@ -80,9 +79,9 @@ class ReportsServiceTest {
 
     @Test
     void should_return_letters_count_excluding_the_test_service() {
-        LocalDate date = LocalDate.now();
-        LocalTime timeFrom = LocalTime.of(17, 0, 0);
-        LocalTime timeTo = LocalTime.of(16, 0, 0);
+        LocalDate date = LocalDate.of(2019, 4, 25);
+        LocalTime timeFrom = LocalTime.parse("17:00");
+        LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
         given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
@@ -104,10 +103,34 @@ class ReportsServiceTest {
     }
 
     @Test
-    void should_return_empty_list_for_the_date_when_repo_returns_empty_collection() {
-        LocalDate date = LocalDate.now();
-        LocalTime timeFrom = LocalTime.of(17, 0, 0);
-        LocalTime timeTo = LocalTime.of(16, 0, 0);
+    void should_return_letters_count_excluding_the_nulls() {
+        LocalDate date = LocalDate.of(2019, 4, 25);
+        LocalTime timeFrom = LocalTime.parse("17:00");
+        LocalTime timeTo = LocalTime.parse("16:00");
+
+        //given
+        given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
+            .willReturn(asList(
+                new ServiceLettersCount("aService", 10),
+                new ServiceLettersCount(null, 2)
+            ));
+        given(serviceFolderMapping.getFolderFor("aService")).willReturn(Optional.of("ServiceA"));
+
+        //when
+        List<LettersCountSummary> result = service.getCountFor(date);
+
+        //then
+        assertThat(result).isNotEmpty()
+            .hasSize(1)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(new LettersCountSummary("ServiceA", 10));
+    }
+
+    @Test
+    void should_map_empty_list_from_repo() {
+        LocalDate date = LocalDate.of(2019, 4, 25);
+        LocalTime timeFrom = LocalTime.parse("17:00");
+        LocalTime timeTo = LocalTime.parse("16:00");
 
         //given
         given(repository.countByDate(formatDateTime(date.minusDays(1), timeFrom), formatDateTime(date, timeTo)))
@@ -121,9 +144,8 @@ class ReportsServiceTest {
     }
 
     private LocalDateTime formatDateTime(LocalDate date, LocalTime time) {
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.of(EUROPE_LONDON));
-        String formattedDateTime = zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
-        return LocalDateTime.parse(formattedDateTime);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.from(ZoneOffset.UTC));
+        return zonedDateTime.toLocalDateTime();
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/ZeroRowFillerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/ZeroRowFillerTest.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.reform.sendletter.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.sendletter.model.out.LettersCountSummary;
+import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ZeroRowFillerTest {
+
+    @Mock
+    private ServiceFolderMapping serviceFolderMapping;
+
+    @Test
+    void should_add_missing_zero_row_when_needed() {
+        //given
+        given(serviceFolderMapping.getFolders()).willReturn(Arrays.asList("ServiceA", "ServiceB", "ServiceC"));
+
+        ZeroRowFiller zeroRowFiller = new ZeroRowFiller(serviceFolderMapping);
+        List<LettersCountSummary> listToFill = asList(
+            new LettersCountSummary("ServiceA", 10),
+            new LettersCountSummary("ServiceB", 15)
+        );
+
+        //when
+        List<LettersCountSummary> result = zeroRowFiller.fill(listToFill);
+
+        //then
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(3)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new LettersCountSummary("ServiceA", 10),
+                new LettersCountSummary("ServiceB", 15),
+                new LettersCountSummary("ServiceC", 0)
+            );
+    }
+
+    @Test
+    void should_add_all_services_when_input_collection_is_empty() {
+        //given
+        given(serviceFolderMapping.getFolders()).willReturn(Arrays.asList("ServiceA", "ServiceB", "ServiceC"));
+
+        ZeroRowFiller zeroRowFiller = new ZeroRowFiller(serviceFolderMapping);
+
+        //when
+        List<LettersCountSummary> result = zeroRowFiller.fill(Collections.emptyList());
+
+        //then
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(3)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new LettersCountSummary("ServiceA", 0),
+                new LettersCountSummary("ServiceB", 0),
+                new LettersCountSummary("ServiceC", 0)
+            );
+    }
+
+    @Test
+    void should_not_change_the_collection_when_all_services_exist() {
+        //given
+        given(serviceFolderMapping.getFolders()).willReturn(Arrays.asList("ServiceA", "ServiceB", "ServiceC"));
+
+        ZeroRowFiller zeroRowFiller = new ZeroRowFiller(serviceFolderMapping);
+        List<LettersCountSummary> listToFill = asList(
+            new LettersCountSummary("ServiceA", 10),
+            new LettersCountSummary("ServiceB", 15),
+            new LettersCountSummary("ServiceC", 1)
+        );
+
+        //when
+        List<LettersCountSummary> result = zeroRowFiller.fill(listToFill);
+
+        //then
+        assertThat(result)
+            .isNotEmpty()
+            .hasSize(3)
+            .usingFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new LettersCountSummary("ServiceA", 10),
+                new LettersCountSummary("ServiceB", 15),
+                new LettersCountSummary("ServiceC", 1)
+            );
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-626

### Change description ###
Added service layer for the letters count report.
The Reports Service excludes the test service, adds a row with count "0" when no letters are uplaoded for the services.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
