### PR TITLE
Fix class type attribute used in agent instrumentation

### DIFF
--- a/lib/AI-Agent.xml
+++ b/lib/AI-Agent.xml
@@ -8,10 +8,10 @@
             <JDBC enabled="true"/>
         </BuiltIn>
 
-        <Class name="uk.gov.hmcts.reform.sendletter.services.encryption.PgpEncryptionUtil" Type="Encryption">
+        <Class name="uk.gov.hmcts.reform.sendletter.services.encryption.PgpEncryptionUtil" type="Encryption">
             <Method name="encryptFile"/>
         </Class>
-        <Class name="uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator" Type="PdfCreator">
+        <Class name="uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator" type="PdfCreator">
             <Method name="createFromTemplates"/>
             <Method name="createFromBase64Pdfs"/>
         </Class>


### PR DESCRIPTION
### Change description ###

Minor amendment after #381. The guidelines I was looking are mainly for .NET and they use capitalised names. But, guidelines include mixture of languages so some of the point is Java some not, no doubt it was misguiding

- [actual code](https://github.com/Microsoft/ApplicationInsights-Java/blob/c19c952e7879797aeca53a41eaccf3946d6039a1/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java#L277)
- [guideline](https://github.com/Microsoft/ApplicationInsights-Java/wiki/Configure-Dependecy-Type-in-the-Agent-Configuration)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
