### PR TITLE
Add email sending feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: versions.springBoot
 
   compile group: 'org.flywaydb', name: 'flyway-core', version: versions.flywayV
   compile group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
@@ -251,6 +252,8 @@ dependencies {
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, {
     exclude group: 'junit', module: 'junit'
   }
+  testCompile group: 'com.icegreen', name: 'greenmail', version: '1.5.10'
+  testCompile group: 'org.apache.commons', name: 'commons-email', version: '1.5'
   testCompile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
   testCompile group: 'org.apache.pdfbox', name: 'preflight', version: versions.pdfbox
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: versions.mockitoJupiter

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderDisabledTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class EmailSenderDisabledTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void should_not_have_report_sender_in_context() {
+        assertThat(context.getBeanNamesForType(EmailSender.class)).isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/Attachment.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/Attachment.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import java.io.File;
+
+class Attachment {
+
+    final String filename;
+    final File file;
+
+    Attachment(String filename, File file) {
+        this.filename = filename;
+        this.file = file;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -52,7 +53,7 @@ public class EmailSender {
             }
 
             mailSender.send(message);
-        } catch (MessagingException exc) {
+        } catch (MessagingException | MailException exc) {
             log.error("Error sending report", exc);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Component
+@ConditionalOnProperty(prefix = "spring.mail", name = "host")
+public class EmailSender {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailSender.class);
+
+    static final String EMAIL_BODY = "This is an auto generated email. Do not respond to it.";
+
+    private final JavaMailSender mailSender;
+    private final String from;
+
+    public EmailSender(
+        JavaMailSender mailSender,
+        @Value("${spring.mail.username}") String from
+    ) {
+        this.mailSender = mailSender;
+        this.from = from;
+    }
+
+    public void send(
+        String subject,
+        String body,
+        String[] recipients,
+        Attachment... attachments
+    ) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+            helper.setFrom(from);
+            helper.setTo(recipients);
+            helper.setSubject(subject);
+            helper.setText(body == null ? EMAIL_BODY : body);
+
+            if (attachments.length > 0) {
+                for (Attachment attachment : attachments) {
+                    helper.addAttachment(attachment.filename, attachment.file);
+                }
+            }
+
+            mailSender.send(message);
+        } catch (MessagingException exc) {
+            log.error("Error sending report", exc);
+        }
+    }
+
+    public void send(
+        String subject,
+        String[] recipients,
+        Attachment... attachments
+    ) {
+        send(subject, null, recipients, attachments);
+    }
+
+    public void send(
+        String subject,
+        String[] recipients
+    ) {
+        send(subject, null, recipients);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
@@ -32,7 +32,6 @@ public class EmailSender {
 
     public void send(
         String subject,
-        String body,
         String[] recipients,
         Attachment... attachments
     ) {
@@ -44,7 +43,7 @@ public class EmailSender {
             helper.setFrom(from);
             helper.setTo(recipients);
             helper.setSubject(subject);
-            helper.setText(body == null ? EMAIL_BODY : body);
+            helper.setText(EMAIL_BODY);
 
             if (attachments.length > 0) {
                 for (Attachment attachment : attachments) {
@@ -56,20 +55,5 @@ public class EmailSender {
         } catch (MessagingException exc) {
             log.error("Error sending report", exc);
         }
-    }
-
-    public void send(
-        String subject,
-        String[] recipients,
-        Attachment... attachments
-    ) {
-        send(subject, null, recipients, attachments);
-    }
-
-    public void send(
-        String subject,
-        String[] recipients
-    ) {
-        send(subject, null, recipients);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSender.java
@@ -52,6 +52,13 @@ public class EmailSender {
                 }
             }
 
+            log.info(
+                "About to send an email '{}' to {} recipients with {} attachments",
+                subject,
+                recipients.length,
+                attachments.length
+            );
+
             mailSender.send(message);
         } catch (MessagingException | MailException exc) {
             log.error("Error sending report", exc);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,9 @@ management:
   endpoints:
     web:
       base-path: /
+  health:
+    mail:
+      enabled: false
 
 idam:
   s2s-auth:
@@ -37,6 +40,20 @@ spring:
           lob:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
+  mail:
+    # defaults will be removed in final PR
+    host: ${SMTP_HOST:false}
+    username: ${SMTP_USERNAME:username}
+    password: ${SMTP_PASSWORD:password}
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    test-connection: false
+
 flyway:
   user: ${LETTER_TRACKING_DB_USER_NAME}
   password: ${LETTER_TRACKING_DB_PASSWORD}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/jupiter/GreenMailExtension.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/jupiter/GreenMailExtension.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.sendletter.jupiter;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailProxy;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This is a copy of not yet released code.
+ * {@see https://github.com/greenmail-mail-test/greenmail/tree/master/greenmail-junit5/src/main/java/com/icegreen/greenmail/junit5}
+ */
+public class GreenMailExtension extends GreenMailProxy implements BeforeEachCallback, AfterEachCallback {
+    private final ServerSetup[] serverSetups;
+    private GreenMail greenMail;
+
+    /**
+     * Initialize with single server setups.
+     *
+     * @param serverSetup Setup to use
+     */
+    public GreenMailExtension(final ServerSetup serverSetup) {
+        this.serverSetups = new ServerSetup[]{serverSetup};
+    }
+
+    /**
+     * Initialize with all server setups.
+     */
+    public GreenMailExtension() {
+        this(ServerSetupTest.ALL);
+    }
+
+    /**
+     * Initialize with multiple server setups.
+     *
+     * @param serverSetups All setups to use
+     */
+    public GreenMailExtension(final ServerSetup[] serverSetups) {
+        this.serverSetups = serverSetups;
+    }
+
+    @Override
+    public void beforeEach(final ExtensionContext context) {
+        greenMail = new GreenMail(serverSetups);
+        start();
+    }
+
+    @Override
+    public void afterEach(final ExtensionContext context) {
+        stop();
+    }
+
+    @Override
+    protected GreenMail getGreenMail() {
+        return greenMail;
+    }
+
+    @Override
+    public GreenMailExtension withConfiguration(final GreenMailConfiguration config) {
+        super.withConfiguration(config);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
@@ -2,17 +2,17 @@ package uk.gov.hmcts.reform.sendletter.tasks.reports;
 
 import com.icegreen.greenmail.util.ServerSetupTest;
 import org.apache.commons.mail.util.MimeMessageParser;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.util.ResourceUtils;
 import uk.gov.hmcts.reform.sendletter.jupiter.GreenMailExtension;
 
 import java.io.File;
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.util.Properties;
 import javax.activation.DataSource;
 import javax.mail.Address;
@@ -40,23 +40,16 @@ class EmailSenderTest {
 
     static {
         try {
-            ATTACHMENT_FILE = File.createTempFile("unit-test", "tst");
+            ATTACHMENT_FILE = ResourceUtils.getFile("classpath:report.csv");
             ATTACHMENT_1 = new Attachment("filename1", ATTACHMENT_FILE);
             ATTACHMENT_2 = new Attachment("filename2", ATTACHMENT_FILE);
-        } catch (IOException exception) {
+        } catch (FileNotFoundException exception) {
             throw new RuntimeException(exception);
         }
     }
 
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
-
-    @AfterAll
-    static void removeTmpFile() {
-        if (ATTACHMENT_FILE != null) {
-            ATTACHMENT_FILE.delete();
-        }
-    }
 
     @Test
     void should_send_to_multiple_recipients_without_attachment() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
@@ -94,26 +94,6 @@ class EmailSenderTest {
             .containsOnly(ATTACHMENT_1.filename, ATTACHMENT_2.filename);
     }
 
-    @Test
-    void should_send_to_recipient_with_custom_body_message() throws Exception {
-        // given
-        EmailSender emailSender = getEmailSender();
-
-        // when
-        emailSender.send(SUBJECT, "some body", new String[] { RECIPIENT_A });
-
-        // then
-        MimeMessageParser mimeMessage = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
-
-        assertThat(mimeMessage.getSubject()).isEqualTo(SUBJECT);
-        assertThat(mimeMessage.getTo())
-            .extracting(Address::toString)
-            .containsOnly(RECIPIENT_A);
-        assertThat(mimeMessage.getFrom()).isEqualTo(TEST_LOGIN);
-        assertThat(mimeMessage.getPlainContent()).isEqualTo("some body");
-        assertThat(mimeMessage.getAttachmentList()).isEmpty();
-    }
-
     private EmailSender getEmailSender() {
         greenMail.setUser(TEST_LOGIN, TEST_PASSWORD);
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.apache.commons.mail.util.MimeMessageParser;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import uk.gov.hmcts.reform.sendletter.jupiter.GreenMailExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import javax.activation.DataSource;
+import javax.mail.Address;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EmailSenderTest {
+
+    private static final String TEST_LOGIN = "test@localhost.com";
+    private static final String TEST_PASSWORD = "test_password";
+
+    private static final String SUBJECT = "email subject";
+    private static final String RECIPIENT_A = "recipient A <a@localhost>";
+    private static final String RECIPIENT_B = "b@localhost";
+    private static final File ATTACHMENT_FILE;
+    private static final Attachment ATTACHMENT_1;
+    private static final Attachment ATTACHMENT_2;
+
+    static {
+        try {
+            ATTACHMENT_FILE = File.createTempFile("unit-test", "tst");
+            ATTACHMENT_1 = new Attachment("filename1", ATTACHMENT_FILE);
+            ATTACHMENT_2 = new Attachment("filename2", ATTACHMENT_FILE);
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
+
+    @AfterAll
+    static void removeTmpFile() {
+        if (ATTACHMENT_FILE != null) {
+            ATTACHMENT_FILE.delete();
+        }
+    }
+
+    @Test
+    void should_send_to_multiple_recipients_without_attachment() throws Exception {
+        // given
+        String[] recipients = new String[] { RECIPIENT_A, RECIPIENT_B };
+        EmailSender emailSender = getEmailSender();
+
+        // when
+        emailSender.send(SUBJECT, recipients);
+
+        // then
+        MimeMessageParser mimeMessage = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
+
+        assertThat(mimeMessage.getSubject()).isEqualTo(SUBJECT);
+        assertThat(mimeMessage.getTo())
+            .extracting(Address::toString)
+            .containsOnly(RECIPIENT_A, RECIPIENT_B);
+        assertThat(mimeMessage.getFrom()).isEqualTo(TEST_LOGIN);
+        assertThat(mimeMessage.getPlainContent()).isEqualTo(EmailSender.EMAIL_BODY);
+        assertThat(mimeMessage.getAttachmentList()).isEmpty();
+    }
+
+    @Test
+    void should_send_to_recipient_with_multiple_attachments() throws Exception {
+        // given
+        EmailSender emailSender = getEmailSender();
+
+        // when
+        emailSender.send(SUBJECT, new String[] { RECIPIENT_B }, ATTACHMENT_1, ATTACHMENT_2);
+
+        // then
+        MimeMessageParser mimeMessage = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
+
+        assertThat(mimeMessage.getSubject()).isEqualTo(SUBJECT);
+        assertThat(mimeMessage.getTo())
+            .extracting(Address::toString)
+            .containsOnly(RECIPIENT_B);
+        assertThat(mimeMessage.getFrom()).isEqualTo(TEST_LOGIN);
+        assertThat(mimeMessage.getPlainContent()).isEqualTo(EmailSender.EMAIL_BODY);
+        assertThat(mimeMessage.getAttachmentList())
+            .hasSize(2)
+            .extracting(DataSource::getName)
+            .containsOnly(ATTACHMENT_1.filename, ATTACHMENT_2.filename);
+    }
+
+    @Test
+    void should_send_to_recipient_with_custom_body_message() throws Exception {
+        // given
+        EmailSender emailSender = getEmailSender();
+
+        // when
+        emailSender.send(SUBJECT, "some body", new String[] { RECIPIENT_A });
+
+        // then
+        MimeMessageParser mimeMessage = new MimeMessageParser(greenMail.getReceivedMessages()[0]).parse();
+
+        assertThat(mimeMessage.getSubject()).isEqualTo(SUBJECT);
+        assertThat(mimeMessage.getTo())
+            .extracting(Address::toString)
+            .containsOnly(RECIPIENT_A);
+        assertThat(mimeMessage.getFrom()).isEqualTo(TEST_LOGIN);
+        assertThat(mimeMessage.getPlainContent()).isEqualTo("some body");
+        assertThat(mimeMessage.getAttachmentList()).isEmpty();
+    }
+
+    private EmailSender getEmailSender() {
+        greenMail.setUser(TEST_LOGIN, TEST_PASSWORD);
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(greenMail.getSmtp().getServerSetup().getBindAddress());
+        mailSender.setPort(ServerSetupTest.SMTP.getPort());
+        mailSender.setUsername(TEST_LOGIN);
+        mailSender.setPassword(TEST_PASSWORD);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", ServerSetupTest.SMTP.getProtocol());
+
+        return new EmailSender(mailSender, TEST_LOGIN);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/EmailSenderTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sendletter.tasks.reports;
 
 import com.icegreen.greenmail.util.ServerSetupTest;
 import org.apache.commons.mail.util.MimeMessageParser;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -34,22 +35,18 @@ class EmailSenderTest {
     private static final String SUBJECT = "email subject";
     private static final String RECIPIENT_A = "recipient A <a@localhost>";
     private static final String RECIPIENT_B = "b@localhost";
-    private static final File ATTACHMENT_FILE;
-    private static final Attachment ATTACHMENT_1;
-    private static final Attachment ATTACHMENT_2;
-
-    static {
-        try {
-            ATTACHMENT_FILE = ResourceUtils.getFile("classpath:report.csv");
-            ATTACHMENT_1 = new Attachment("filename1", ATTACHMENT_FILE);
-            ATTACHMENT_2 = new Attachment("filename2", ATTACHMENT_FILE);
-        } catch (FileNotFoundException exception) {
-            throw new RuntimeException(exception);
-        }
-    }
+    private static Attachment ATTACHMENT_1;
+    private static Attachment ATTACHMENT_2;
 
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
+
+    @BeforeAll
+    static void setUp() throws FileNotFoundException {
+        File report = ResourceUtils.getFile("classpath:report.csv");
+        ATTACHMENT_1 = new Attachment("filename1", report);
+        ATTACHMENT_2 = new Attachment("filename2", report);
+    }
 
     @Test
     void should_send_to_multiple_recipients_without_attachment() throws Exception {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate send letter daily report](https://tools.hmcts.net/jira/browse/BPS-627)

### Change description ###

Introducing email sender component as stand-alone feature. No knowledge of contents/reports or any body if necessary. Brings in wide enough usage samples in case report does not need attachment but just some html body in there - can be provided by report separately. Or not report at all.

Ideally this should be a tiny library on it's own as similar implementation is in bulk scan project and potentially can be in others due to the nature of implementation introduced here

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
