### PR TITLE
Introduce daily report for summary of uploaded letters

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportDisabledTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class DailyLetterUploadSummaryReportDisabledTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void should_not_have_report_sender_in_context() {
+        assertThat(context.getBeanNamesForType(DailyLetterUploadSummaryReport.class)).isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import net.javacrumbs.shedlock.core.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sendletter.model.out.LettersCountSummary;
+import uk.gov.hmcts.reform.sendletter.services.ReportsService;
+import uk.gov.hmcts.reform.sendletter.util.CsvWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
+
+@Component
+@ConditionalOnProperty(prefix = "spring.mail", name = "host")
+public class DailyLetterUploadSummaryReport {
+
+    private static final Logger log = LoggerFactory.getLogger(DailyLetterUploadSummaryReport.class);
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private static final String EMAIL_SUBJECT = "Sent Letters Summary split by services";
+    private static final String ATTACHMENT_PREFIX = "send-letter-summary-";
+
+    private final ReportsService reportService;
+
+    private final EmailSender emailSender;
+
+    private final String[] recipients;
+
+    public DailyLetterUploadSummaryReport(
+        ReportsService reportService,
+        EmailSender emailSender,
+        @Value("${reports.upload-summary.recipients}") String[] recipients
+    ) {
+        this.reportService = reportService;
+        this.emailSender = emailSender;
+
+        if (recipients == null) {
+            this.recipients = new String[0];
+        } else {
+            this.recipients = Arrays.copyOf(recipients, recipients.length);
+        }
+
+        if (this.recipients.length == 0) {
+            log.warn("No recipients configured for reports");
+        }
+    }
+
+    @SchedulerLock(name = "daily-letter-upload-summary")
+    @Scheduled(cron = "${reports.upload-summary.cron}", zone = EUROPE_LONDON)
+    public void send() {
+        LocalDate today = LocalDate.now();
+        log.info("Generating report '{}' for '{}'", EMAIL_SUBJECT, today);
+
+        try {
+            List<LettersCountSummary> summary = reportService.getCountFor(today);
+            File csv = CsvWriter.writeLettersCountSummaryToCsv(summary);
+            Attachment attachment = new Attachment(ATTACHMENT_PREFIX + today.format(FORMATTER) + ".csv", csv);
+
+            emailSender.send(EMAIL_SUBJECT, recipients, attachment);
+
+            log.info("Report '{}' sent", EMAIL_SUBJECT);
+        } catch (IOException exception) {
+            log.error("Unable to generate report '{}'", EMAIL_SUBJECT, exception);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,10 @@ spring:
             enable: true
     test-connection: false
 
+reports:
+  upload-summary:
+    recipients:
+
 flyway:
   user: ${LETTER_TRACKING_DB_USER_NAME}
   password: ${LETTER_TRACKING_DB_PASSWORD}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import uk.gov.hmcts.reform.sendletter.services.ReportsService;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import javax.mail.internet.MimeMessage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DailyLetterUploadSummaryReportTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private ReportsService reportService;
+
+    private EmailSender emailSender;
+
+    @BeforeEach
+    void setUp() {
+        emailSender = new EmailSender(mailSender, "unit@test");
+    }
+
+    @Test
+    void should_send_a_report_to_single_recipient() {
+        // given
+        given(reportService.getCountFor(LocalDate.now())).willReturn(Collections.emptyList());
+        given(mailSender.createMimeMessage()).willReturn(new JavaMailSenderImpl().createMimeMessage());
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+        DailyLetterUploadSummaryReport report = new DailyLetterUploadSummaryReport(
+            reportService,
+            emailSender,
+            new String[] { "test@localhost" }
+        );
+
+        // when
+        report.send();
+
+        // then
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void should_attempt_to_send_a_report_when_no_recipients_are_configured() {
+        // given
+        given(reportService.getCountFor(LocalDate.now())).willReturn(Collections.emptyList());
+        given(mailSender.createMimeMessage()).willReturn(new JavaMailSenderImpl().createMimeMessage());
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+        DailyLetterUploadSummaryReport report = new DailyLetterUploadSummaryReport(reportService, emailSender, null);
+
+        // when
+        report.send();
+
+        // then
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.sendletter.tasks.reports;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -11,8 +13,11 @@ import uk.gov.hmcts.reform.sendletter.services.ReportsService;
 
 import java.time.LocalDate;
 import java.util.Collections;
+import javax.mail.Address;
+import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -20,6 +25,9 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class DailyLetterUploadSummaryReportTest {
+
+    @Captor
+    private ArgumentCaptor<MimeMessage> mimeMessageCaptor;
 
     @Mock
     private JavaMailSender mailSender;
@@ -35,26 +43,32 @@ class DailyLetterUploadSummaryReportTest {
     }
 
     @Test
-    void should_send_a_report_to_single_recipient() {
+    void should_send_a_report_to_single_recipient() throws MessagingException {
         // given
+        String recipient = "test@localhost";
         given(reportService.getCountFor(LocalDate.now())).willReturn(Collections.emptyList());
         given(mailSender.createMimeMessage()).willReturn(new JavaMailSenderImpl().createMimeMessage());
         doNothing().when(mailSender).send(any(MimeMessage.class));
         DailyLetterUploadSummaryReport report = new DailyLetterUploadSummaryReport(
             reportService,
             emailSender,
-            new String[] { "test@localhost" }
+            new String[] { recipient }
         );
 
         // when
         report.send();
 
         // then
-        verify(mailSender).send(any(MimeMessage.class));
+        verify(mailSender).send(mimeMessageCaptor.capture());
+
+        // and
+        assertThat(mimeMessageCaptor.getValue().getAllRecipients())
+            .extracting(Address::toString)
+            .containsOnly(recipient);
     }
 
     @Test
-    void should_attempt_to_send_a_report_when_no_recipients_are_configured() {
+    void should_attempt_to_send_a_report_when_no_recipients_are_configured() throws MessagingException {
         // given
         given(reportService.getCountFor(LocalDate.now())).willReturn(Collections.emptyList());
         given(mailSender.createMimeMessage()).willReturn(new JavaMailSenderImpl().createMimeMessage());
@@ -65,6 +79,9 @@ class DailyLetterUploadSummaryReportTest {
         report.send();
 
         // then
-        verify(mailSender).send(any(MimeMessage.class));
+        verify(mailSender).send(mimeMessageCaptor.capture());
+
+        // and
+        assertThat(mimeMessageCaptor.getValue().getAllRecipients()).isNull(); // library doesn't assign empty arrays
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate send letter daily report](https://tools.hmcts.net/jira/browse/BPS-627)

### Change description ###

Incorporate #394 and #392 to send out an email. Which is disabled at the moment. All the changes are non-effective and left for final (next) PR.

This is another set of "purely additions" PR without breaking anything existing. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
