### PR TITLE
Feature: enable daily report task

### DIFF
--- a/charts/rpe-send-letter-service/values.template.yaml
+++ b/charts/rpe-send-letter-service/values.template.yaml
@@ -25,6 +25,8 @@ java:
     FTP_FINGERPRINT: "SHA256:gYzreAtWAraVRFsOrcP9SPJq9atn7QxXh9pAauKud2U"
     FTP_TARGET_FOLDER: "TO_XEROX"
     FTP_REPORTS_FOLDER: "FROM_XEROX"
+    # mails
+    SPRING_MAIL_HOST: "false"
   keyVaults:
     "rpe-send-letter":
       resourceGroup: rpe-send-letter-service

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -119,6 +119,7 @@ module "send-letter-service" {
 
     // reports. depends on smtp
     UPLOAD_SUMMARY_REPORT_CRON       = "${var.upload_summary_report_cron}"
+    UPLOAD_SUMMARY_REPORT_ENABLED    = "${var.upload_summary_report_enabled}"
     UPLOAD_SUMMARY_REPORT_RECIPIENTS = "${data.azurerm_key_vault_secret.upload_summary_recipients.value}"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -111,6 +111,15 @@ module "send-letter-service" {
     FTP_PRIVATE_KEY                 = "${local.ftp_private_key}"
     FTP_PUBLIC_KEY                  = "${local.ftp_public_key}"
     ENCRYPTION_PUBLIC_KEY           = "${local.encryption_public_key}"
+
+    // smtp
+    SMTP_HOST          = "${var.smtp_host}"
+    SMTP_USERNAME      = "${data.azurerm_key_vault_secret.smtp_username.value}"
+    SMTP_PASSWORD      = "${data.azurerm_key_vault_secret.smtp_password.value}"
+
+    // reports. depends on smtp
+    UPLOAD_SUMMARY_REPORT_CRON       = "${var.upload_summary_report_cron}"
+    UPLOAD_SUMMARY_REPORT_RECIPIENTS = "${data.azurerm_key_vault_secret.upload_summary_recipients.value}"
   }
 }
 
@@ -158,3 +167,18 @@ resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
   vault_uri = "${module.send-letter-key-vault.key_vault_uri}"
 }
 # endregion
+
+data "azurerm_key_vault_secret" "smtp_username" {
+  name         = "reports-email-username"
+  key_vault_id = "${module.send-letter-key-vault.key_vault_id}"
+}
+
+data "azurerm_key_vault_secret" "smtp_password" {
+  name         = "reports-email-password"
+  key_vault_id = "${module.send-letter-key-vault.key_vault_id}"
+}
+
+data "azurerm_key_vault_secret" "upload_summary_recipients" {
+  name         = "upload-summary-report-recipients"
+  key_vault_id = "${module.send-letter-key-vault.key_vault_id}"
+}

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -4,3 +4,5 @@ encyption_enabled = "true"
 file_cleanup_enabled = "false"
 
 capacity = "2"
+
+smtp_host = "smtp.office365.com"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -6,3 +6,5 @@ file_cleanup_enabled = "false"
 capacity = "2"
 
 smtp_host = "smtp.office365.com"
+
+upload_summary_report_enabled = "true"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,6 +120,10 @@ variable "upload_summary_report_cron" {
   description = "Cron signature for job to send daily summary report of uploaded letters"
 }
 
+variable "upload_summary_report_enabled" {
+  default = "false"
+}
+
 # endregion
 
 variable "deployment_namespace" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -107,6 +107,21 @@ variable "ftp_reports_cron" {
   default = "0 30 10 * * *"
 }
 
+variable "smtp_host" {
+  type        = "string"
+  default     = "false"
+  description = "SMTP host for sending out reports via JavaMailSender"
+}
+
+# region reports
+
+variable "upload_summary_report_cron" {
+  default     = "0 0 19 * * *"
+  description = "Cron signature for job to send daily summary report of uploaded letters"
+}
+
+# endregion
+
 variable "deployment_namespace" {
   default = ""
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportDisabledByComponentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportDisabledByComponentTest.java
@@ -8,9 +8,9 @@ import org.springframework.context.ApplicationContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = {
-    "reports.upload-summary.enabled=false"
+    "spring.mail.host=false"
 })
-public class DailyLetterUploadSummaryReportDisabledTest {
+public class DailyLetterUploadSummaryReportDisabledByComponentTest {
 
     @Autowired
     private ApplicationContext context;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportDisabledTest.java
@@ -7,7 +7,9 @@ import org.springframework.context.ApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+    "spring.mail.host=false"
+})
 public class DailyLetterUploadSummaryReportDisabledTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import javax.mail.internet.MimeMessage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class DailyLetterUploadSummaryReportTest {
+
+    @Autowired
+    private DailyLetterUploadSummaryReport report;
+
+    @SpyBean
+    private JavaMailSender mailSender;
+
+    @Test
+    public void should_attempt_to_send_report_when_recipients_list_is_present() {
+        report.send();
+
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+}

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -23,3 +23,10 @@ ftp.service-folders[0].folder=some_folder
 flyway.noop.strategy=false
 
 stale-letters.min-age-in-business-days=2
+
+spring.mail.host=smpth.localhost
+spring.mail.username=username
+spring.mail.password=password
+spring.mail.test-connection=false
+
+reports.upload-summary.recipients=integration@test

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -29,4 +29,5 @@ spring.mail.username=username
 spring.mail.password=password
 spring.mail.test-connection=false
 
+reports.upload-summary.enabled=true
 reports.upload-summary.recipients=integration@test

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -4,6 +4,7 @@ import net.javacrumbs.shedlock.core.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,7 +22,8 @@ import java.util.List;
 import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 @Component
-@ConditionalOnProperty(prefix = "spring.mail", name = "host")
+@ConditionalOnBean(EmailSender.class)
+@ConditionalOnProperty(prefix = "reports.upload-summary", name = "enabled")
 public class DailyLetterUploadSummaryReport {
 
     private static final Logger log = LoggerFactory.getLogger(DailyLetterUploadSummaryReport.class);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,7 @@ spring:
 reports:
   upload-summary:
     cron: ${UPLOAD_SUMMARY_REPORT_CRON:0 0 19 * * *}
+    enabled: ${UPLOAD_SUMMARY_REPORT_ENABLED:false}
     recipients: ${UPLOAD_SUMMARY_REPORT_RECIPIENTS:}
 
 flyway:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,10 +41,9 @@ spring:
             # silence the 'wall-of-text' - unnecessary exception throw about blob types
             non_contextual_creation: true
   mail:
-    # defaults will be removed in final PR
-    host: ${SMTP_HOST:false}
-    username: ${SMTP_USERNAME:username}
-    password: ${SMTP_PASSWORD:password}
+    host: ${SMTP_HOST}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
     port: 587
     properties:
       mail:
@@ -52,11 +51,12 @@ spring:
           auth: true
           starttls:
             enable: true
-    test-connection: false
+    test-connection: true
 
 reports:
   upload-summary:
-    recipients:
+    cron: ${UPLOAD_SUMMARY_REPORT_CRON:0 0 19 * * *}
+    recipients: ${UPLOAD_SUMMARY_REPORT_RECIPIENTS:}
 
 flyway:
   user: ${LETTER_TRACKING_DB_USER_NAME}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate send letter daily report](https://tools.hmcts.net/jira/browse/BPS-627)

### Change description ###

Going through configuration and infrastructure to enable report for prod only. The secrets are not yet created and will confirm once they are by removing the `DO NOT MERGE` label. Will not start creating secrets until PR is not approved as it will confirm that naming is acceptable.

This PR introduces config separation among different beans: both `EmailSender` and `DailyLetterUploadSummaryReport` was dependant on single config value - `spring.mail.host` which is only relevant for former. Report itself should not repeat this so providing 2 conditions: new flag plus condition on `EmailSender` bean being present (it is dependency).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
