### PR TITLE
Update report by shortcutting execution

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -56,7 +56,7 @@ public class DailyLetterUploadSummaryReport {
     @Scheduled(cron = "${reports.upload-summary.cron}", zone = EUROPE_LONDON)
     public void send() {
         if (recipients.length == 0) {
-            log.error("No recipients configured for reports");
+            log.error("No recipients configured for '{}' report", EMAIL_SUBJECT);
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -50,15 +50,16 @@ public class DailyLetterUploadSummaryReport {
         } else {
             this.recipients = Arrays.copyOf(recipients, recipients.length);
         }
-
-        if (this.recipients.length == 0) {
-            log.warn("No recipients configured for reports");
-        }
     }
 
     @SchedulerLock(name = "daily-letter-upload-summary")
     @Scheduled(cron = "${reports.upload-summary.cron}", zone = EUROPE_LONDON)
     public void send() {
+        if (recipients.length == 0) {
+            log.warn("No recipients configured for reports");
+            return;
+        }
+
         LocalDate today = LocalDate.now();
         log.info("Generating report '{}' for '{}'", EMAIL_SUBJECT, today);
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -56,7 +56,7 @@ public class DailyLetterUploadSummaryReport {
     @Scheduled(cron = "${reports.upload-summary.cron}", zone = EUROPE_LONDON)
     public void send() {
         if (recipients.length == 0) {
-            log.warn("No recipients configured for reports");
+            log.error("No recipients configured for reports");
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -50,13 +50,16 @@ public class DailyLetterUploadSummaryReport {
         } else {
             this.recipients = Arrays.copyOf(recipients, recipients.length);
         }
+
+        if (this.recipients.length == 0) {
+            log.error("No recipients configured for '{}' report", EMAIL_SUBJECT);
+        }
     }
 
     @SchedulerLock(name = "daily-letter-upload-summary")
     @Scheduled(cron = "${reports.upload-summary.cron}", zone = EUROPE_LONDON)
     public void send() {
         if (recipients.length == 0) {
-            log.error("No recipients configured for '{}' report", EMAIL_SUBJECT);
             return;
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReportTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,20 +69,15 @@ class DailyLetterUploadSummaryReportTest {
     }
 
     @Test
-    void should_attempt_to_send_a_report_when_no_recipients_are_configured() throws MessagingException {
+    void should_not_send_a_report_when_no_recipients_are_configured() {
         // given
-        given(reportService.getCountFor(LocalDate.now())).willReturn(Collections.emptyList());
-        given(mailSender.createMimeMessage()).willReturn(new JavaMailSenderImpl().createMimeMessage());
-        doNothing().when(mailSender).send(any(MimeMessage.class));
         DailyLetterUploadSummaryReport report = new DailyLetterUploadSummaryReport(reportService, emailSender, null);
 
         // when
         report.send();
 
         // then
-        verify(mailSender).send(mimeMessageCaptor.capture());
-
-        // and
-        assertThat(mimeMessageCaptor.getValue().getAllRecipients()).isNull(); // library doesn't assign empty arrays
+        verify(reportService, never()).getCountFor(any(LocalDate.class));
+        verify(mailSender, never()).send(any(MimeMessage.class));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Automate send letter daily report](https://tools.hmcts.net/jira/browse/BPS-627)

### Change description ###

As raised in #396, short-circuiting task execution to minimum in case known key component for sending out email is missing. Raising such situation to `error` level.

Tiny bonus: improved/fixed log message

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
