### PR TITLE
Remove jUnit4 (again)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,10 @@ dependencyManagement {
 }
 
 dependencies {
+  def withoutJunit4 = {
+    exclude group: 'junit', module: 'junit'
+  }
+
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
@@ -249,9 +253,7 @@ dependencies {
   compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: versions.bouncycastle
   compile group: 'org.bouncycastle', name: 'bcpg-jdk15on', version: versions.bouncycastle
 
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, {
-    exclude group: 'junit', module: 'junit'
-  }
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
   testCompile group: 'com.icegreen', name: 'greenmail', version: '1.5.10'
   testCompile group: 'org.apache.commons', name: 'commons-email', version: '1.5'
   testCompile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
@@ -271,12 +273,12 @@ dependencies {
 
   smokeTestCompile sourceSets.main.runtimeClasspath
   smokeTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
-  smokeTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+  smokeTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
   smokeTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
-  functionalTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+  functionalTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
   functionalTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ dependencies {
   testCompile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
   testCompile group: 'org.apache.pdfbox', name: 'preflight', version: versions.pdfbox
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: versions.mockitoJupiter
-  testCompile group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.23.2'
+  testCompile group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.23.2', withoutJunit4
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 

--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ dependencies {
   compile group: 'org.bouncycastle', name: 'bcpg-jdk15on', version: versions.bouncycastle
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
-  testCompile group: 'com.icegreen', name: 'greenmail', version: '1.5.10'
+  testCompile group: 'com.icegreen', name: 'greenmail', version: '1.5.10', withoutJunit4
   testCompile group: 'org.apache.commons', name: 'commons-email', version: '1.5'
   testCompile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
   testCompile group: 'org.apache.pdfbox', name: 'preflight', version: versions.pdfbox

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Change description ###

Was removed only from test and integration scope. Smoke and functional tests do not include test compiles and has separate spring boot testing framework there with junit4. 😇 missed in #350

Since #394 new `greenmail` dependency also dragged it in. Currently we don't need junit4 as same (#394) PR introduced custom extension as a replacement for junit4 `Rule`s

-- edit --

#401 - wiremock dependency drags it in too

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
