### PR TITLE
BPS-638 Add service display name to service folder mappings config

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
@@ -15,7 +15,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
     "tasks.mark-letters-posted=*/1 * * * * *",
     "tasks.stale-letters-report=*/1 * * * * *",
     "ftp.service-folders[0].service=some_service_name",
-    "ftp.service-folders[0].folder=BULKPRINT"
+    "ftp.service-folders[0].folder=BULKPRINT",
+    "ftp.service-folders[0].display-name=Bulk Print"
 })
 class EndToEndTest extends BaseTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndWithEncryptionEnabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndWithEncryptionEnabledTest.java
@@ -16,7 +16,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
     "tasks.mark-letters-posted=*/1 * * * * *",
     "tasks.stale-letters-report=*/1 * * * * *",
     "ftp.serviceFolders[0].service=some_service_name",
-    "ftp.serviceFolders[0].folder=BULKPRINT"
+    "ftp.serviceFolders[0].folder=BULKPRINT",
+    "ftp.serviceFolders[0].display-name=Bulk Print"
 })
 class EndToEndWithEncryptionEnabledTest extends BaseTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/helper/FtpHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/helper/FtpHelper.java
@@ -4,7 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import net.schmizz.sshj.SSHClient;
 import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties;
-import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties.ServiceFolderMapping;
+import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties.ServiceNameFolderMapping;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
@@ -51,10 +51,11 @@ public final class FtpHelper {
         p.setFingerprint("SHA1:2Fo8c/96zv32xc8GZWbOGYOlRak=");
         p.setTargetFolder(LocalSftpServer.LETTERS_FOLDER_NAME);
         p.setReportsFolder(LocalSftpServer.REPORT_FOLDER_NAME);
-        ServiceFolderMapping serviceFolderMapping = new ServiceFolderMapping();
-        serviceFolderMapping.setService("bulkprint");
-        serviceFolderMapping.setFolder("BULKPRINT");
-        p.setServiceFolders(singletonList(serviceFolderMapping));
+        ServiceNameFolderMapping serviceNameFolderConfig = new ServiceNameFolderMapping();
+        serviceNameFolderConfig.setService("bulkprint");
+        serviceNameFolderConfig.setFolder("BULKPRINT");
+        serviceNameFolderConfig.setDisplayName("BULKPRINT");
+        p.setServicesConfig(singletonList(serviceNameFolderConfig));
         return p;
     }
 }

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -19,6 +19,7 @@ ftp.downtime.to: 23:59
 
 ftp.service-folders[0].service=some_service_name
 ftp.service-folders[0].folder=some_folder
+ftp.service-folders[0].displayName=some folder
 
 flyway.noop.strategy=false
 

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -19,7 +19,7 @@ ftp.downtime.to: 23:59
 
 ftp.service-folders[0].service=some_service_name
 ftp.service-folders[0].folder=some_folder
-ftp.service-folders[0].displayName=some folder
+ftp.service-folders[0].display-name=some folder
 
 flyway.noop.strategy=false
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/FtpConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/FtpConfigProperties.java
@@ -3,9 +3,6 @@ package uk.gov.hmcts.reform.sendletter.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
-import java.util.Map;
-
-import static java.util.stream.Collectors.toMap;
 
 @ConfigurationProperties(prefix = "ftp")
 public class FtpConfigProperties {
@@ -28,14 +25,15 @@ public class FtpConfigProperties {
 
     private String reportsFolder;
 
-    private Map<String, String> serviceFolders;
+    private List<ServiceNameFolderMapping> servicesConfig;
 
-    public static class ServiceFolderMapping {
+    public static class ServiceNameFolderMapping {
 
         private String service;
         private String folder;
+        private String displayName;
 
-        public ServiceFolderMapping() {
+        public ServiceNameFolderMapping() {
             // Spring needs it.
         }
 
@@ -53,6 +51,14 @@ public class FtpConfigProperties {
 
         public void setFolder(String folder) {
             this.folder = folder;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public void setDisplayName(String displayName) {
+            this.displayName = displayName;
         }
         // endregion
     }
@@ -137,13 +143,11 @@ public class FtpConfigProperties {
         this.reportsFolder = reportsFolder;
     }
 
-    public Map<String, String> getServiceFolders() {
-        return serviceFolders;
+    public List<ServiceNameFolderMapping> getServicesConfig() {
+        return servicesConfig;
     }
 
-    public void setServiceFolders(List<ServiceFolderMapping> serviceFolders) {
-        this.serviceFolders = serviceFolders
-            .stream()
-            .collect(toMap(ServiceFolderMapping::getService, ServiceFolderMapping::getFolder));
+    public void setServicesConfig(List<ServiceNameFolderMapping> servicesConfig) {
+        this.servicesConfig = servicesConfig;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/ServiceFolderMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/ServiceFolderMapping.java
@@ -2,9 +2,12 @@ package uk.gov.hmcts.reform.sendletter.services.ftp;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties;
+import uk.gov.hmcts.reform.sendletter.config.FtpConfigProperties.ServiceNameFolderMapping;
 
 import java.util.Collection;
 import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
 
 @Component
 public class ServiceFolderMapping {
@@ -16,10 +19,15 @@ public class ServiceFolderMapping {
     }
 
     public Collection<String> getFolders() {
-        return configProperties.getServiceFolders().values();
+        return configProperties.getServicesConfig()
+            .stream()
+            .map(ServiceNameFolderMapping::getFolder).collect(toList());
     }
 
     public Optional<String> getFolderFor(String serviceName) {
-        return Optional.ofNullable(configProperties.getServiceFolders().get(serviceName));
+        return configProperties.getServicesConfig()
+            .stream().filter(config -> config.getDisplayName().equals(serviceName))
+            .map(ServiceNameFolderMapping::getFolder)
+            .findFirst();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,17 +75,22 @@ ftp:
   downtime:
     from: ${FTP_DOWNTIME_FROM:16:00}
     to: ${FTP_DOWNTIME_TO:17:00}
-  service-folders:
+  services-config:
     - service: cmc_claim_store
       folder: CMC
+      displayName: CMC
     - service: send_letter_tests
       folder: BULKPRINT
+      displayName: Bulk Print
     - service: divorce_frontend
       folder: DIVORCE
+      displayName: Divorce
     - service: probate_backend
       folder: PROBATE
+      displayName: Probate
     - service: sscs
       folder: SSCS
+      displayName: SSCS
 
 scheduling:
   enabled: ${SCHEDULING_ENABLED:false}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,19 +78,19 @@ ftp:
   services-config:
     - service: cmc_claim_store
       folder: CMC
-      displayName: CMC
+      display-name: CMC
     - service: send_letter_tests
       folder: BULKPRINT
-      displayName: Bulk Print
+      display-name: Bulk Print
     - service: divorce_frontend
       folder: DIVORCE
-      displayName: Divorce
+      display-name: Divorce
     - service: probate_backend
       folder: PROBATE
-      displayName: Probate
+      display-name: Probate
     - service: sscs
       folder: SSCS
-      displayName: SSCS
+      display-name: SSCS
 
 scheduling:
   enabled: ${SCHEDULING_ENABLED:false}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-638


### Change description ###
Added service display name property to the existing service folder mappings.
Letters count report will use the new property instead of the folder name in the next PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
