### PR TITLE
Move the letter -> stale letter mapping to the controller

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterController.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.model.out.StaleLetter;
 import uk.gov.hmcts.reform.sendletter.model.out.StaleLetterResponse;
 import uk.gov.hmcts.reform.sendletter.services.StaleLetterService;
@@ -32,10 +33,21 @@ public class StaleLetterController {
         @ApiResponse(code = 500, message = "Error occurred while retrieving stale letters")
     })
     public StaleLetterResponse getStaleLetters() {
-        try (Stream<StaleLetter> staleLetters = staleLetterService.getStaleLetters()) {
+        try (Stream<Letter> letters = staleLetterService.getStaleLetters()) {
             return new StaleLetterResponse(
-                staleLetters.collect(toList())
+                letters.map(this::mapToStaleLetter).collect(toList())
             );
         }
+    }
+
+    private StaleLetter mapToStaleLetter(Letter dbLetter) {
+        return new StaleLetter(
+            dbLetter.getId(),
+            dbLetter.getStatus().name(),
+            dbLetter.getService(),
+            dbLetter.getCreatedAt(),
+            dbLetter.getSentToPrintAt(),
+            dbLetter.isFailed()
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterService.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
-import uk.gov.hmcts.reform.sendletter.model.out.StaleLetter;
 import uk.gov.hmcts.reform.sendletter.services.date.DateCalculator;
 
 import java.time.Clock;
@@ -43,14 +42,12 @@ public class StaleLetterService {
         this.clock = clock;
     }
 
-    public Stream<StaleLetter> getStaleLetters() {
-        Stream<Letter> dbLetters = letterRepository.findStaleLetters(
+    public Stream<Letter> getStaleLetters() {
+        return letterRepository.findStaleLetters(
             calculateCutOffCreationDate()
                 .withZoneSameInstant(DB_TIME_ZONE_ID)
                 .toLocalDateTime()
         );
-
-        return dbLetters.map(this::mapToStaleLetter);
     }
 
     /**
@@ -80,17 +77,6 @@ public class StaleLetterService {
         return dateCalculator.subtractBusinessDays(
             todayWithFtpDowntimeAdjustedTime,
             minStaleLetterAgeInBusinessDays
-        );
-    }
-
-    private StaleLetter mapToStaleLetter(Letter dbLetter) {
-        return new StaleLetter(
-            dbLetter.getId(),
-            dbLetter.getStatus().name(),
-            dbLetter.getService(),
-            dbLetter.getCreatedAt(),
-            dbLetter.getSentToPrintAt(),
-            dbLetter.isFailed()
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterControllerTest.java
@@ -7,7 +7,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.sendletter.model.out.StaleLetter;
+import uk.gov.hmcts.reform.sendletter.entity.Letter;
+import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.services.StaleLetterService;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.io.Resources.getResource;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -32,24 +34,26 @@ public class StaleLetterControllerTest {
 
     @Test
     public void should_return_letters_from_stale_letter_service() throws Exception {
-        given(staleLetterService.getStaleLetters()).willReturn(Stream.of(
-            new StaleLetter(
+        Stream<Letter> letters = Stream.of(
+            letter(
                 UUID.fromString("767cf17e-0ec0-452b-a457-bc173d51ff40"),
-                "status1",
                 "service1",
+                LetterStatus.Uploaded,
+                false,
                 LocalDateTime.parse("2019-05-03T12:34:56.123"),
-                LocalDateTime.parse("2019-05-03T13:00:00.000"),
-                false
+                LocalDateTime.parse("2019-05-03T13:00:00.000")
             ),
-            new StaleLetter(
+            letter(
                 UUID.fromString("462a58fe-e9b7-494f-a719-5083f31c69cf"),
-                "status2",
                 "service2",
+                LetterStatus.Created,
+                true,
                 LocalDateTime.parse("2019-05-02T10:11:22.321"),
-                null,
-                true
+                null
             )
-        ));
+        );
+
+        given(staleLetterService.getStaleLetters()).willReturn(letters);
 
         mockMvc
             .perform(get("/stale-letters").accept(MediaType.APPLICATION_JSON_VALUE))
@@ -76,5 +80,25 @@ public class StaleLetterControllerTest {
                     .accept(MediaType.APPLICATION_JSON_VALUE)
             )
             .andExpect(status().is5xxServerError());
+    }
+
+    private Letter letter(
+        UUID id,
+        String service,
+        LetterStatus status,
+        Boolean isFailed,
+        LocalDateTime createdAt,
+        LocalDateTime sentToPrintAt
+    ) {
+        Letter letter = mock(Letter.class);
+
+        given(letter.getId()).willReturn(id);
+        given(letter.getSentToPrintAt()).willReturn(sentToPrintAt);
+        given(letter.getCreatedAt()).willReturn(createdAt);
+        given(letter.getService()).willReturn(service);
+        given(letter.getStatus()).willReturn(status);
+        given(letter.isFailed()).willReturn(isFailed);
+
+        return letter;
     }
 }

--- a/src/test/resources/controller/stale-letters/stale-letters-response.json
+++ b/src/test/resources/controller/stale-letters/stale-letters-response.json
@@ -2,7 +2,7 @@
   "stale_letters": [
     {
       "id": "767cf17e-0ec0-452b-a457-bc173d51ff40",
-      "status": "status1",
+      "status": "Uploaded",
       "service": "service1",
       "created_at": "2019-05-03T12:34:56.123",
       "sent_to_print_at": "2019-05-03T13:00:00",
@@ -10,7 +10,7 @@
     },
     {
       "id": "462a58fe-e9b7-494f-a719-5083f31c69cf",
-      "status": "status2",
+      "status": "Created",
       "service": "service2",
       "created_at": "2019-05-02T10:11:22.321",
       "sent_to_print_at": null,


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Move the mapping from letter to stale letter from `StaleLetterService` to `StaleLetterController`. The service needs to return letters in order to be usable by `StaleLettersTask` (stale letters don't contain all the information it uses).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
