### PR TITLE
Retrieve stale letters as a list, not a stream

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/StaleLetterSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/StaleLetterSearchTest.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.sendletter.SampleData;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -30,7 +29,7 @@ public class StaleLetterSearchTest {
         Letter uploadedLetter = storeLetter(cutOffDate.minusDays(5), LetterStatus.Uploaded);
 
         // when
-        List<Letter> letters = repository.findStaleLetters(cutOffDate).collect(toList());
+        List<Letter> letters = repository.findStaleLetters(cutOffDate);
 
         // then
         assertThat(letters.size()).isEqualTo(2);
@@ -49,7 +48,7 @@ public class StaleLetterSearchTest {
         Letter abortedLetter = storeLetter(cutOffDate.minusSeconds(1), LetterStatus.Aborted);
 
         // when
-        List<Letter> letters = repository.findStaleLetters(cutOffDate).collect(toList());
+        List<Letter> letters = repository.findStaleLetters(cutOffDate);
 
         // then
         assertThat(letters.size()).isEqualTo(2);
@@ -66,7 +65,7 @@ public class StaleLetterSearchTest {
         storeLetter(cutOffDate.plusSeconds(1), LetterStatus.Created);
 
         // when
-        List<Letter> letters = repository.findStaleLetters(cutOffDate).collect(toList());
+        List<Letter> letters = repository.findStaleLetters(cutOffDate);
 
         // then
         assertThat(letters).isEmpty();
@@ -81,7 +80,7 @@ public class StaleLetterSearchTest {
         storeLetter(cutOffDate.minusDays(1), LetterStatus.Created, "not-smoke-test");
 
         // when
-        List<Letter> letters = repository.findStaleLetters(cutOffDate).collect(toList());
+        List<Letter> letters = repository.findStaleLetters(cutOffDate);
 
         // then
         assertThat(letters.size()).isEqualTo(1);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterController.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.sendletter.model.out.StaleLetter;
 import uk.gov.hmcts.reform.sendletter.model.out.StaleLetterResponse;
 import uk.gov.hmcts.reform.sendletter.services.StaleLetterService;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
@@ -33,11 +33,14 @@ public class StaleLetterController {
         @ApiResponse(code = 500, message = "Error occurred while retrieving stale letters")
     })
     public StaleLetterResponse getStaleLetters() {
-        try (Stream<Letter> letters = staleLetterService.getStaleLetters()) {
-            return new StaleLetterResponse(
-                letters.map(this::mapToStaleLetter).collect(toList())
-            );
-        }
+        List<StaleLetter> staleLetters =
+            staleLetterService
+                .getStaleLetters()
+                .stream()
+                .map(this::mapToStaleLetter)
+                .collect(toList());
+
+        return new StaleLetterResponse(staleLetters);
     }
 
     private StaleLetter mapToStaleLetter(Letter dbLetter) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -21,7 +21,7 @@ public interface LetterRepository extends JpaRepository<Letter, UUID> {
         + " and l.createdAt < :createdBefore and l.type <> '"
         + UploadLettersTask.SMOKE_TEST_LETTER_TYPE
         + "' order by l.createdAt asc")
-    Stream<Letter> findStaleLetters(
+    List<Letter> findStaleLetters(
         @Param("createdBefore") LocalDateTime createdBefore
     );
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterService.java
@@ -10,7 +10,7 @@ import java.time.Clock;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.stream.Stream;
+import java.util.List;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
@@ -42,7 +42,7 @@ public class StaleLetterService {
         this.clock = clock;
     }
 
-    public Stream<Letter> getStaleLetters() {
+    public List<Letter> getStaleLetters() {
         return letterRepository.findStaleLetters(
             calculateCutOffCreationDate()
                 .withZoneSameInstant(DB_TIME_ZONE_ID)

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/StaleLetterControllerTest.java
@@ -12,8 +12,9 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.services.StaleLetterService;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.io.Resources.getResource;
@@ -34,7 +35,7 @@ public class StaleLetterControllerTest {
 
     @Test
     public void should_return_letters_from_stale_letter_service() throws Exception {
-        Stream<Letter> letters = Stream.of(
+        List<Letter> letters = Arrays.asList(
             letter(
                 UUID.fromString("767cf17e-0ec0-452b-a457-bc173d51ff40"),
                 "service1",

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterServiceTest.java
@@ -17,11 +17,10 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.DAYS;
-import static java.util.stream.Collectors.toList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -45,7 +44,7 @@ public class StaleLetterServiceTest {
 
     @BeforeEach
     public void setUp() {
-        given(letterRepository.findStaleLetters(any())).willReturn(Stream.of());
+        given(letterRepository.findStaleLetters(any())).willReturn(emptyList());
         given(dateCalculator.subtractBusinessDays(any(), anyInt())).willReturn(ZonedDateTime.now());
 
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of(EUROPE_LONDON));
@@ -124,14 +123,14 @@ public class StaleLetterServiceTest {
             mock(Letter.class)
         );
 
-        given(letterRepository.findStaleLetters(any())).willReturn(repositoryLetters.stream());
+        given(letterRepository.findStaleLetters(any())).willReturn(repositoryLetters);
 
         // when
-        Stream<Letter> staleLetters =
+        List<Letter> staleLetters =
             staleLetterService("16:00", 2).getStaleLetters();
 
         // then
-        assertThat(staleLetters.collect(toList())).hasSameElementsAs(repositoryLetters);
+        assertThat(staleLetters).hasSameElementsAs(repositoryLetters);
     }
 
     private StaleLetterService staleLetterService(String ftpDowntimeStart, int minStaleLetterAgeInBusinessDays) {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTaskTest.java
@@ -12,9 +12,10 @@ import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.StaleLetterService;
 
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static java.time.LocalDateTime.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -40,7 +41,7 @@ class StaleLettersTaskTest {
     @Test
     void should_do_nothing_when_there_are_no_unprinted_letters() {
         // given
-        given(staleLetterService.getStaleLetters()).willReturn(Stream.empty());
+        given(staleLetterService.getStaleLetters()).willReturn(emptyList());
 
         // when
         task.run();
@@ -55,7 +56,7 @@ class StaleLettersTaskTest {
         // given
         Letter letter = staleLetter();
 
-        given(staleLetterService.getStaleLetters()).willReturn(Stream.of(letter));
+        given(staleLetterService.getStaleLetters()).willReturn(asList(letter));
 
         // when
         task.run();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-621

### Change description ###

Retrieve stale letters as a list, not a stream. Choosing stream was premature, as it requires transaction. Stale letters endpoint returns all stale letters, so we read all the data, anyway.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
