### PR TITLE
 Ensure proper formatting of ZonedDateTime fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/LetterStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/LetterStatus.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sendletter.model.out;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -7,6 +8,9 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 
 public class LetterStatus {
+
+    // TODO: replace with a proper global solution - BPS-639
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     public final UUID id;
 
@@ -20,12 +24,15 @@ public class LetterStatus {
     public final String checksum;
 
     @JsonProperty("created_at")
+    @JsonFormat(pattern = DATE_TIME_PATTERN)
     public final ZonedDateTime createdAt;
 
     @JsonProperty("sent_to_print_at")
+    @JsonFormat(pattern = DATE_TIME_PATTERN)
     public final ZonedDateTime sentToPrintAt;
 
     @JsonProperty("printed_at")
+    @JsonFormat(pattern = DATE_TIME_PATTERN)
     public final ZonedDateTime printedAt;
 
     @JsonProperty("has_failed")


### PR DESCRIPTION
### Change description ###

Ensure proper formatting of ZonedDateTime fields in letter status response. Before this change the length of the millisecond component wasn't constant and integration tests expected a fixed format, failing intermittently.

This is a quick fix to stabilise builds. Should be followed by a proper solution (https://tools.hmcts.net/jira/browse/BPS-639)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
