### PR TITLE
Extend lock duration for reporting job

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyLetterUploadSummaryReport.java
@@ -58,7 +58,7 @@ public class DailyLetterUploadSummaryReport {
         }
     }
 
-    @SchedulerLock(name = "daily-letter-upload-summary")
+    @SchedulerLock(name = "daily-letter-upload-summary", lockAtLeastFor = 5_000)
     @Scheduled(cron = "${reports.upload-summary.cron}", zone = EUROPE_LONDON)
     public void send() {
         if (recipients.length == 0) {


### PR DESCRIPTION
to prevent sending 2 emails (from 2 instances)