### PR TITLE
Update schedule duration calculation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/AspectConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/AspectConfiguration.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.Instant;
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.getCurrentEuropeLondonInstant;
 
 @Aspect
 @Configuration
@@ -68,7 +68,7 @@ public class AspectConfiguration {
     ) {
         if (requestTelemetry != null) {
             requestTelemetry.setName(requestName);
-            requestTelemetry.setDuration(new Duration(Instant.now().toEpochMilli() - start));
+            requestTelemetry.setDuration(new Duration(getCurrentEuropeLondonInstant().toEpochMilli() - start));
             requestTelemetry.setSuccess(success);
 
             // in case telemetry client is not configured/enabled

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/ThreadPoolConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/ThreadPoolConfig.java
@@ -12,14 +12,13 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
-import uk.gov.hmcts.reform.sendletter.util.TimeZones;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.getCurrentEuropeLondonInstant;
 
 /**
  * Adds custom error handler to Scheduled Tasks. Followed suggestions by Microsoft.
@@ -32,11 +31,7 @@ public class ThreadPoolConfig implements SchedulingConfigurer {
     private static AtomicInteger errorCount = new AtomicInteger(0);
     private static final Logger log = LoggerFactory.getLogger(ThreadPoolConfig.class);
 
-    private static final Supplier<Long> CURRENT_MILLIS_SUPPLIER = () -> LocalDateTime
-        .now()
-        .atZone(ZoneId.of(TimeZones.EUROPE_LONDON))
-        .toInstant()
-        .toEpochMilli();
+    private static final Supplier<Long> CURRENT_MILLIS_SUPPLIER = () -> getCurrentEuropeLondonInstant().toEpochMilli();
 
     private static final Supplier<RequestTelemetryContext> REQUEST_CONTEXT_SUPPLIER = () ->
         new RequestTelemetryContext(CURRENT_MILLIS_SUPPLIER.get(), null);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/util/TimeZones.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/util/TimeZones.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sendletter.util;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,5 +20,12 @@ public final class TimeZones {
     public static LocalDateTime localDateTimeWithUtc(LocalDate date, LocalTime time) {
         ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.from(ZoneOffset.UTC));
         return zonedDateTime.toLocalDateTime();
+    }
+
+    public static Instant getCurrentEuropeLondonInstant() {
+        return LocalDateTime
+            .now()
+            .atZone(ZoneId.of(EUROPE_LONDON))
+            .toInstant();
     }
 }


### PR DESCRIPTION
### Change description ###

Fixing timezoned instant used in request telemetry. Keeping timezoned as behind the scenes app insights might use the value. All metrics at the moment are with extra hour 🙂

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
