### PR TITLE
Bump shedlock library 2.4.0 -> 2.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ def versions = [
   pdfbox: '2.0.15',
   reformLogging: '5.0.1',
   restAssured: '3.3.0',
-  shedlock: '2.4.0',
+  shedlock: '2.5.0',
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   springfoxSwagger: '2.9.2'
 ]


### PR DESCRIPTION
### Change description ###

Contains changes which we don't use:
- log messages
- spring 2.2 testing
- zookeeper changes
- readme updates

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
