### PR TITLE
Close open pdf document left behind (fun tests)

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTest.java
@@ -105,8 +105,9 @@ class ProcessMessageTest extends FunctionalTestSuite {
             PdfFile pdfFile = unzipFile(zipFile);
             assertThat(pdfFile.name).matches(getPdfFileNamePattern(letterId));
 
-            PDDocument pdfDocument = PDDocument.load(pdfFile.content);
-            assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
+            try (PDDocument pdfDocument = PDDocument.load(pdfFile.content)) {
+                assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
+            }
         }
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
@@ -65,8 +65,9 @@ class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             PdfFile pdfFile = unzipFile(zipFile);
             assertThat(pdfFile.name).matches(getPdfFileNamePattern(letterId));
 
-            PDDocument pdfDocument = PDDocument.load(pdfFile.content);
-            assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
+            try (PDDocument pdfDocument = PDDocument.load(pdfFile.content)) {
+                assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
+            }
         }
     }
 


### PR DESCRIPTION
### Change description ###

Took long time to eye on this warning but today it happened. Another PR failed on functional test step just for _good_ measure. Nothing related to the change but occasionally this step fails and simply needs a re-run

Back to this PR - closing PDF document for **actual good** measure 🙂

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
