### PR TITLE
Fix/timeout upload corruption

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -71,6 +72,14 @@ public class FtpClient {
             isSuccess = true;
         } catch (IOException exc) {
             logger.error("Error uploading file. Path: {}", path, exc);
+
+            if (exc.getCause() instanceof TimeoutException) {
+                logger.error("Timeout error while uploading file. Path: {}", path, exc);
+                // deleting as file is corrupt and will break printing provider
+                deleteFile(path, sftpClient);
+                // this ^ can also cause FtpException. In case not - we will have the following FtpException
+            }
+
             throw new FtpException("Unable to upload file.", exc);
         } finally {
             insights.trackFtpUpload(Duration.between(start, Instant.now()), isSuccess);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -71,13 +71,13 @@ public class FtpClient {
 
             isSuccess = true;
         } catch (IOException exc) {
-            logger.error("Error uploading file. Path: {}", path, exc);
-
             if (exc.getCause() instanceof TimeoutException) {
-                logger.error("Timeout error while uploading file. Path: {}", path, exc);
+                logger.error("Timeout error while uploading file. Deleting corrupt file. Path: {}", path, exc);
                 // deleting as file is corrupt and will break printing provider
                 deleteFile(path, sftpClient);
                 // this ^ can also cause FtpException. In case not - we will have the following FtpException
+            } else {
+                logger.error("Error uploading file. Path: {}", path, exc);
             }
 
             throw new FtpException("Unable to upload file.", exc);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Send Letter File Size Error](https://tools.hmcts.net/jira/browse/BPS-646)

### Change description ###

Jira title perhaps should be amended as incident has been recognised:

1. multi instances picked up same entry in DB and trying to process
2. last but least successfully uploaded and marked as "uploaded"
3. last timed out as it took too long to finish the upload (at the time we experienced big latency in file upload process so it might as well be a legit timeout)

The successful upload summary:
```
File uploaded. Time: 15357ms, Size: 1994KB, Folder: PROBATE
```

This PR introduces extra handle in case such situation happens. Library throws wrapped `TimeoutException` with `SFTPException` which is extension of `IOException`. So it allows to put in directly where we handle it currently. Plus with the help of #377 and #406 the handling becomes straight-forward.
This purely depends on latency - we did not receive too big of a file to keep on failing. That being said, the next task run will pick up the db entry and retry the upload

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
