### PR TITLE
Feature: custom health type telemetry processor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/TracingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/TracingConfiguration.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
+import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
 import org.springframework.boot.actuate.trace.http.Include;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,5 +13,25 @@ public class TracingConfiguration {
     @Bean
     public SensitiveHeadersRequestTraceFilter requestTraceFilter() {
         return new SensitiveHeadersRequestTraceFilter(Include.defaultIncludes());
+    }
+
+    /**
+     * Custom {@link TelemetryProcessor} which amends the type of {@link RemoteDependencyTelemetry} before publishing.
+     * Within 1h service consumes thousands of health related checks and therefore silences the actual dependencies.
+     * We want to be able to recognise REAL dependency from those which are health related.
+     */
+    @Bean
+    public TelemetryProcessor healthRecognitionProcessor() {
+        return telemetry -> {
+            String operationName = telemetry.getContext().getOperation().getName();
+
+            if (telemetry instanceof RemoteDependencyTelemetry && operationName != null) {
+                if (operationName.contains("/health")) {
+                    ((RemoteDependencyTelemetry) telemetry).setType("Health");
+                }
+            }
+
+            return true;
+        };
     }
 }


### PR DESCRIPTION
### Change description ###

Fixing clash of dependencies which originate from `/health`. This separation will produce clearer results and actual values of dependencies.

Before:

type | name | operation_Name
--- | --- | ---
Http (tracked component) | GET /health | GET /health
SQL | SQL: jdbc:postgresql://rpe-send... | GET /health
SQL | SQL: jdbc:postgresql://rpe-send... | GET /health
Http (tracked component) | GET /health | GET /health
Http (tracked component) | GET /health | GET /health
SQL | SQL: jdbc:postgresql://rpe-send... | GET /health
SQL | SQL: jdbc:postgresql://rpe-send... | GET /health
Http (tracked component) | GET /health | GET /health
SQL | SQL: jdbc:postgresql://rpe-send... | GET /health
Http (tracked component) | GET /health | GET /health

After:

type | name | operation_Name
--- | --- | ---
Health | GET /health | GET /health
Health | GET /health | GET /health
Health | jdbc:postgresql://rpe-send-lett... | GET /health
Health | jdbc:postgresql://rpe-send-lett... | GET /health
Health | GET /health | GET /health
Health | GET /health | GET /health
Health | jdbc:postgresql://rpe-send-lett... | GET /health
Health | GET /health | GET /health
Health | jdbc:postgresql://rpe-send-lett... | GET /health
Health | GET /health | GET /health

Application map sample from demo:

<img width="604" alt="application-map" src="https://user-images.githubusercontent.com/1420191/58086079-d8e9aa80-7bb5-11e9-892f-3eb26996df71.png">

Note. Circular dependency (health checks) is still present and known issue 😥

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
