### PR TITLE
Bump jackson-databind 2.9.8 -> 2.9.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,12 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
       entry 'mockito-core'
     }
+    // solves CVE-2019-12086
+    // remove once spring manager incorporates this changes
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9') {
+      entry 'jackson-core'
+      entry 'jackson-databind'
+    }
   }
 }
 


### PR DESCRIPTION
### Change description ###

Solve [CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
