### PR TITLE
Fix jackson2 (Local|Zoned)DateTime serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ task integration(type: Test) {
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
 
-  environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
   environment("FTP_PRIVATE_KEY", file('src/integrationTest/resources/keypair').text)
   environment("FTP_PUBLIC_KEY", file('src/integrationTest/resources/keypair.pub').text)
   environment("ENCRYPTION_PUBLIC_KEY", file('src/integrationTest/resources/encryption/pubkey.asc').text)

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -34,3 +34,5 @@ spring.mail.test-connection=false
 
 reports.upload-summary.enabled=true
 reports.upload-summary.recipients=integration@test
+
+azure.application-insights.instrumentation-key=integration-test

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/TimeConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/TimeConfiguration.java
@@ -1,15 +1,36 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
+import java.time.format.DateTimeFormatter;
 
 @Configuration
 public class TimeConfiguration {
 
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
     @Bean
     public Clock clock() {
         return Clock.systemDefaultZone();
+    }
+
+    // global setting via config files not working with java8
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomiser() {
+        return builder -> {
+            builder.simpleDateFormat(DATE_TIME_PATTERN);
+
+            builder.serializers(
+                new LocalDateSerializer(DateTimeFormatter.ISO_LOCAL_DATE),
+                new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN)),
+                new ZonedDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN))
+            );
+        };
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/LetterStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/LetterStatus.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sendletter.model.out;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -8,9 +7,6 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 
 public class LetterStatus {
-
-    // TODO: replace with a proper global solution - BPS-639
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     public final UUID id;
 
@@ -24,15 +20,12 @@ public class LetterStatus {
     public final String checksum;
 
     @JsonProperty("created_at")
-    @JsonFormat(pattern = DATE_TIME_PATTERN)
     public final ZonedDateTime createdAt;
 
     @JsonProperty("sent_to_print_at")
-    @JsonFormat(pattern = DATE_TIME_PATTERN)
     public final ZonedDateTime sentToPrintAt;
 
     @JsonProperty("printed_at")
-    @JsonFormat(pattern = DATE_TIME_PATTERN)
     public final ZonedDateTime printedAt;
 
     @JsonProperty("has_failed")


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Serialise (Local|Zoned)DateTime fields to contain full millisecond component](https://tools.hmcts.net/jira/browse/BPS-639)

### Change description ###

To globally apply config we need to introduce `Jackson2ObjectMapperBuilderCustomizer` bean.

Bonus: moving application insights instrumentation key to application properties - allows to run integration tests via IDE if there is such desire

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
