### PR TITLE
Fix invalid log message

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -176,7 +176,7 @@ public class FtpClient {
                 return action.apply(sftp);
             }
         } catch (IOException exc) {
-            throw new FtpException("Unable to upload file.", exc);
+            throw new FtpException("FTP operation failed.", exc);
         } finally {
             try {
                 if (ssh != null) {


### PR DESCRIPTION
This was logged in `public <T> T runWith(Function<SFTPClient, T> action) {` method
which is called from:
- downloadReports()
- deleteReport()
- listLetters()
- testConnection()