### PR TITLE
Extract duplicated test code into existing test suite

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
@@ -8,7 +8,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.RemoteFile;
-import net.schmizz.sshj.sftp.SFTPClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -141,7 +140,7 @@ abstract class FunctionalTestSuite {
         return requestBody.replace("{{pdf}}", new String(Base64.getEncoder().encode(pdf)));
     }
 
-    SFTPClient getSftpClient() throws IOException {
+    SSHClient getSshClient() throws IOException {
         SSHClient ssh = new SSHClient();
 
         ssh.addHostKeyVerifier(ftpFingerprint);
@@ -152,7 +151,7 @@ abstract class FunctionalTestSuite {
             ssh.loadKeys(ftpPrivateKey, ftpPublicKey, null)
         );
 
-        return ssh.newSFTPClient();
+        return ssh;
     }
 
     ZipInputStream getZipInputStream(RemoteFile zipFile) throws IOException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
@@ -8,6 +8,9 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.RemoteFile;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
+import net.schmizz.sshj.sftp.SFTPClient;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -19,13 +22,21 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
+import static org.apache.commons.lang.time.DateUtils.addMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.DateUtil.now;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -194,6 +205,87 @@ abstract class FunctionalTestSuite {
             Pattern.quote(s2sName.replace("_", "")),
             Pattern.quote(letterId)
         );
+    }
+
+    void awaitAndVerifyFileOnSftp(
+        String letterId,
+        BiConsumer<RemoteResourceInfo, SFTPClient> action
+    ) throws IOException, InterruptedException {
+        Date waitUntil = addMilliseconds(now(), maxWaitForFtpFileInMs);
+
+        Boolean fileExists = false;
+
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
+
+            while (!(now().after(waitUntil) || fileExists)) {
+                Optional<RemoteResourceInfo> matchingFile = findSingleFileOnSftp(letterId, sftp);
+
+                if (matchingFile.isPresent()) {
+                    fileExists = true;
+                    action.accept(matchingFile.get(), sftp);
+                } else {
+                    Thread.sleep(1000);
+                }
+            }
+
+            if (!fileExists) {
+                throw new AssertionError("The expected file didn't appear on SFTP server");
+            }
+        }
+    }
+
+    private Optional<RemoteResourceInfo> findSingleFileOnSftp(
+        String letterId,
+        SFTPClient sftp
+    ) throws IOException {
+        String lettersFolder = String.join("/", ftpTargetFolder, "BULKPRINT");
+
+        List<RemoteResourceInfo> matchingFiles = sftp.ls(lettersFolder, file -> file.getName().contains(letterId));
+
+        if (matchingFiles.size() > 1) {
+            String failMessage = String.format(
+                "Expected one file with name containing '%s'. Found %d",
+                letterId,
+                matchingFiles.size()
+            );
+
+            throw new AssertionError(failMessage);
+        } else {
+            return matchingFiles.stream().findFirst();
+        }
+    }
+
+    void validatePdfFile(
+        String letterId,
+        SFTPClient sftp,
+        RemoteResourceInfo sftpFile,
+        int noOfDocuments
+    ) {
+        try (RemoteFile zipFile = sftp.open(sftpFile.getPath())) {
+            PdfFile pdfFile = unzipFile(zipFile);
+            assertThat(pdfFile.name).matches(getPdfFileNamePattern(letterId));
+
+            try (PDDocument pdfDocument = PDDocument.load(pdfFile.content)) {
+                assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
+            }
+        } catch (IOException e) {
+            fail("Failed to validate PDF file", e);
+        }
+    }
+
+    PdfFile unzipFile(RemoteFile zipFile) throws IOException {
+        try (ZipInputStream zipStream = getZipInputStream(zipFile)) {
+            ZipEntry firstEntry = zipStream.getNextEntry();
+            byte[] pdfContent = readAllBytes(zipStream);
+
+            ZipEntry secondEntry = zipStream.getNextEntry();
+            assertThat(secondEntry).as("second file in zip").isNull();
+
+            String pdfName = firstEntry.getName();
+
+            return new PdfFile(pdfName, pdfContent);
+        }
     }
 
     static class PdfFile {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTest.java
@@ -1,25 +1,11 @@
 package uk.gov.hmcts.reform.sendletter;
 
-import net.schmizz.sshj.SSHClient;
-import net.schmizz.sshj.sftp.RemoteFile;
-import net.schmizz.sshj.sftp.RemoteResourceInfo;
-import net.schmizz.sshj.sftp.SFTPClient;
-import org.apache.pdfbox.pdmodel.PDDocument;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.sendletter.controllers.MediaTypes;
 
-import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
-import static org.apache.commons.lang.time.DateUtils.addMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.util.DateUtil.now;
 
 @ExtendWith(SpringExtension.class)
 class ProcessMessageTest extends FunctionalTestSuite {
@@ -32,16 +18,13 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_single_document.json", "two-page-template.html")
         );
 
-        try (SSHClient ssh = getSshClient()) {
-            SFTPClient sftp = ssh.newSFTPClient();
-            RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
-
+        awaitAndVerifyFileOnSftp(letterId, (sftpFile, sftp) -> {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
                 validatePdfFile(letterId, sftp, sftpFile, 2);
             }
-        }
+        });
     }
 
     @Test
@@ -52,16 +35,13 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_single_document.json", "one-page-template.html")
         );
 
-        try (SSHClient ssh = getSshClient()) {
-            SFTPClient sftp = ssh.newSFTPClient();
-            RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
-
+        awaitAndVerifyFileOnSftp(letterId, (sftpFile, sftp) -> {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
                 validatePdfFile(letterId, sftp, sftpFile, 2);
             }
-        }
+        });
     }
 
     @Test
@@ -72,16 +52,13 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_two_documents.json", "two-page-template.html")
         );
 
-        try (SSHClient ssh = getSshClient()) {
-            SFTPClient sftp = ssh.newSFTPClient();
-            RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
-
+        awaitAndVerifyFileOnSftp(letterId, (sftpFile, sftp) -> {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
                 validatePdfFile(letterId, sftp, sftpFile, 4);
             }
-        }
+        });
     }
 
     @Test
@@ -92,72 +69,13 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_two_documents.json", "one-page-template.html")
         );
 
-        try (SSHClient ssh = getSshClient()) {
-            SFTPClient sftp = ssh.newSFTPClient();
-            RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
-
+        awaitAndVerifyFileOnSftp(letterId, (sftpFile, sftp) -> {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
                 validatePdfFile(letterId, sftp, sftpFile, 4);
             }
-        }
-    }
-
-    private void validatePdfFile(String letterId, SFTPClient sftp, RemoteResourceInfo sftpFile, int noOfDocuments)
-        throws IOException {
-        try (RemoteFile zipFile = sftp.open(sftpFile.getPath())) {
-            PdfFile pdfFile = unzipFile(zipFile);
-            assertThat(pdfFile.name).matches(getPdfFileNamePattern(letterId));
-
-            try (PDDocument pdfDocument = PDDocument.load(pdfFile.content)) {
-                assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
-            }
-        }
-    }
-
-    private RemoteResourceInfo waitForFileOnSftp(
-        SFTPClient sftp, String letterId
-    ) throws IOException, InterruptedException {
-        Date waitUntil = addMilliseconds(now(), maxWaitForFtpFileInMs);
-
-        List<RemoteResourceInfo> matchingFiles;
-
-        String lettersFolder = String.join("/", ftpTargetFolder, "BULKPRINT");
-
-        while (!now().after(waitUntil)) {
-            matchingFiles = sftp.ls(lettersFolder, file -> file.getName().contains(letterId));
-
-            if (matchingFiles.size() == 1) {
-                return matchingFiles.get(0);
-            } else if (matchingFiles.size() > 1) {
-                String failMessage = String.format(
-                    "Expected one file with name containing '%s'. Found %d",
-                    letterId,
-                    matchingFiles.size()
-                );
-
-                fail(failMessage);
-            } else {
-                Thread.sleep(1000);
-            }
-        }
-
-        throw new AssertionError("The expected file didn't appear on SFTP server");
-    }
-
-    private PdfFile unzipFile(RemoteFile zipFile) throws IOException {
-        try (ZipInputStream zipStream = getZipInputStream(zipFile)) {
-            ZipEntry firstEntry = zipStream.getNextEntry();
-            byte[] pdfContent = readAllBytes(zipStream);
-
-            ZipEntry secondEntry = zipStream.getNextEntry();
-            assertThat(secondEntry).as("second file in zip").isNull();
-
-            String pdfName = firstEntry.getName();
-
-            return new PdfFile(pdfName, pdfContent);
-        }
+        });
     }
 
     @Override

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sendletter;
 
+import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.RemoteFile;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
@@ -31,7 +32,8 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_single_document.json", "two-page-template.html")
         );
 
-        try (SFTPClient sftp = getSftpClient()) {
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
             RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
 
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
@@ -50,7 +52,8 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_single_document.json", "one-page-template.html")
         );
 
-        try (SFTPClient sftp = getSftpClient()) {
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
             RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
 
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
@@ -69,7 +72,8 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_two_documents.json", "two-page-template.html")
         );
 
-        try (SFTPClient sftp = getSftpClient()) {
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
             RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
 
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
@@ -88,7 +92,8 @@ class ProcessMessageTest extends FunctionalTestSuite {
             sampleLetterRequestJson("letter_two_documents.json", "one-page-template.html")
         );
 
-        try (SFTPClient sftp = getSftpClient()) {
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
             RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
 
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sendletter;
 
+import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.RemoteFile;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
@@ -30,7 +31,8 @@ class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             samplePdfLetterRequestJson("letter-with-single-pdf.json")
         );
 
-        try (SFTPClient sftp = getSftpClient()) {
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
             RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
 
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
@@ -48,7 +50,8 @@ class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             samplePdfLetterRequestJson("letter-with-two-pdfs.json")
         );
 
-        try (SFTPClient sftp = getSftpClient()) {
+        try (SSHClient ssh = getSshClient()) {
+            SFTPClient sftp = ssh.newSFTPClient();
             RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
 
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/ProcessMessageTestForPdfEndpoint.java
@@ -1,25 +1,11 @@
 package uk.gov.hmcts.reform.sendletter;
 
-import net.schmizz.sshj.SSHClient;
-import net.schmizz.sshj.sftp.RemoteFile;
-import net.schmizz.sshj.sftp.RemoteResourceInfo;
-import net.schmizz.sshj.sftp.SFTPClient;
-import org.apache.pdfbox.pdmodel.PDDocument;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.sendletter.controllers.MediaTypes;
 
-import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
-import static org.apache.commons.lang.time.DateUtils.addMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.util.DateUtil.now;
 
 @ExtendWith(SpringExtension.class)
 class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
@@ -31,16 +17,13 @@ class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             samplePdfLetterRequestJson("letter-with-single-pdf.json")
         );
 
-        try (SSHClient ssh = getSshClient()) {
-            SFTPClient sftp = ssh.newSFTPClient();
-            RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
-
+        awaitAndVerifyFileOnSftp(letterId, (sftpFile, sftp) -> {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
                 validatePdfFile(letterId, sftp, sftpFile, 2);
             }
-        }
+        });
     }
 
     @Test
@@ -50,73 +33,13 @@ class ProcessMessageTestForPdfEndpoint extends FunctionalTestSuite {
             samplePdfLetterRequestJson("letter-with-two-pdfs.json")
         );
 
-        try (SSHClient ssh = getSshClient()) {
-            SFTPClient sftp = ssh.newSFTPClient();
-            RemoteResourceInfo sftpFile = waitForFileOnSftp(sftp, letterId);
-
+        awaitAndVerifyFileOnSftp(letterId, (sftpFile, sftp) -> {
             assertThat(sftpFile.getName()).matches(getFileNamePattern(letterId));
 
             if (!isEncryptionEnabled) {
                 validatePdfFile(letterId, sftp, sftpFile, 4);
             }
-        }
-    }
-
-    private void validatePdfFile(String letterId, SFTPClient sftp, RemoteResourceInfo sftpFile, int noOfDocuments)
-        throws IOException {
-        try (RemoteFile zipFile = sftp.open(sftpFile.getPath())) {
-            PdfFile pdfFile = unzipFile(zipFile);
-            assertThat(pdfFile.name).matches(getPdfFileNamePattern(letterId));
-
-            try (PDDocument pdfDocument = PDDocument.load(pdfFile.content)) {
-                assertThat(pdfDocument.getNumberOfPages()).isEqualTo(noOfDocuments);
-            }
-        }
-    }
-
-    private RemoteResourceInfo waitForFileOnSftp(
-        SFTPClient sftp, String letterId
-    ) throws IOException, InterruptedException {
-        Date waitUntil = addMilliseconds(now(), maxWaitForFtpFileInMs);
-
-        List<RemoteResourceInfo> matchingFiles;
-
-        String lettersFolder = String.join("/", ftpTargetFolder, "BULKPRINT");
-
-
-        while (!now().after(waitUntil)) {
-            matchingFiles = sftp.ls(lettersFolder, file -> file.getName().contains(letterId));
-
-            if (matchingFiles.size() == 1) {
-                return matchingFiles.get(0);
-            } else if (matchingFiles.size() > 1) {
-                String failMessage = String.format(
-                    "Expected one file with name containing '%s'. Found %d",
-                    letterId,
-                    matchingFiles.size()
-                );
-
-                fail(failMessage);
-            } else {
-                Thread.sleep(1000);
-            }
-        }
-
-        throw new AssertionError("The expected file didn't appear on SFTP server");
-    }
-
-    private PdfFile unzipFile(RemoteFile zipFile) throws IOException {
-        try (ZipInputStream zipStream = getZipInputStream(zipFile)) {
-            ZipEntry firstEntry = zipStream.getNextEntry();
-            byte[] pdfContent = readAllBytes(zipStream);
-
-            ZipEntry secondEntry = zipStream.getNextEntry();
-            assertThat(secondEntry).as("second file in zip").isNull();
-
-            String pdfName = firstEntry.getName();
-
-            return new PdfFile(pdfName, pdfContent);
-        }
+        });
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -172,9 +172,7 @@ public class FtpClient {
                 )
             );
 
-            try (SFTPClient sftp = ssh.newSFTPClient()) {
-                return action.apply(sftp);
-            }
+            return action.apply(ssh.newSFTPClient());
         } catch (IOException exc) {
             throw new FtpException("Unable to upload file.", exc);
         } finally {


### PR DESCRIPTION
### Change description ###

This PR is build on top of https://github.com/hmcts/send-letter-service/pull/449 - should merge that one first.

Extract duplicated test code into existing test suite. As the next step, we can think about splitting the suite into purpose-specific utilities (authentication, SFTP stuff, etc).

These changes are optional. Some of them might be controversial, to if you don't like them, please let me know.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
