### PR TITLE
Load 3 letters to download at a time instead of 10

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public interface LetterRepository extends JpaRepository<Letter, UUID> {
 
-    List<Letter> findFirst10ByStatus(LetterStatus status);
+    List<Letter> findFirst3ByStatus(LetterStatus status);
 
     List<Letter> findByStatus(LetterStatus status);
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -64,7 +64,7 @@ public class UploadLettersTask {
 
         // Upload the letters in batches.
         // With each batch we mark them Uploaded/Skipped so they no longer appear in the query.
-        List<Letter> lettersToUpload = repo.findFirst10ByStatus(LetterStatus.Created);
+        List<Letter> lettersToUpload = repo.findFirst3ByStatus(LetterStatus.Created);
         int counter = 0;
 
         if (!lettersToUpload.isEmpty()) {
@@ -73,7 +73,7 @@ public class UploadLettersTask {
                 List<Letter> letters;
 
                 do {
-                    letters = repo.findFirst10ByStatus(LetterStatus.Created);
+                    letters = repo.findFirst3ByStatus(LetterStatus.Created);
                     uploaded += uploadLetters(letters, sftpClient);
                 } while (!letters.isEmpty());
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -193,7 +193,7 @@ class UploadLettersTaskTest {
     @SuppressWarnings("unchecked")
     private void givenDbContains(Letter... letters) {
         // Return letter on first call, then empty list.
-        given(repo.findFirst10ByStatus(eq(Created)))
+        given(repo.findFirst3ByStatus(eq(Created)))
             .willReturn(Arrays.asList(letters)).willReturn(Lists.newArrayList());
     }
 }


### PR DESCRIPTION
### Change description ###

Load 3 letters to download at a time instead of 10, as a quick solution of OutOfMemoryError. To be replaced by lazy loading of file content.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
