### PR TITLE
Change FTP file cleanup cron, so that it runs every hour

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -75,8 +75,8 @@ variable "file_cleanup_enabled" {
 }
 
 variable "file_cleanup_cron" {
-  default     = "0 0 5 * * *"
-  description = "Crontab value for task to be run. Default - 5AM server time"
+  default     = "0 15 * * * *"
+  description = "Crontab value for task to be run"
 }
 
 variable scheduling_lock_at_most_for {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -110,7 +110,7 @@ tasks:
 
 file-cleanup:
   enabled: ${FILE_CLEANUP_ENABLED:false}
-  cron: ${FILE_CLEANUP_CRON:0 0 5 * * *}
+  cron: ${FILE_CLEANUP_CRON:0 15 * * * *}
   ttl: 12h
 
 encryption:


### PR DESCRIPTION
### Change description ###

Change FTP file cleanup cron, so that it runs every hour. It doesn't delete files newer than 12h, anyway.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
