### PR TITLE
Fix date formatting in tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sendletter.SampleData;
+import uk.gov.hmcts.reform.sendletter.config.TimeConfiguration;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 
@@ -80,6 +81,8 @@ class GetLetterStatusTest {
     }
 
     private String toIso(LocalDateTime dateTime) {
-        return dateTime.atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_INSTANT);
+        return dateTime
+            .atZone(ZoneId.of("UTC"))
+            .format(DateTimeFormatter.ofPattern(TimeConfiguration.DATE_TIME_PATTERN));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/TimeConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/TimeConfiguration.java
@@ -13,7 +13,7 @@ import java.time.format.DateTimeFormatter;
 @Configuration
 public class TimeConfiguration {
 
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     @Bean
     public Clock clock() {


### PR DESCRIPTION
Recently a test on Travis started failing consistently:
```
uk.gov.hmcts.reform.sendletter.controllers.GetLetterStatusTest
>should_return_200_when_matching_letter_found_in_db() FAILED

{{ java.lang.AssertionError: 
  JSON path "$.created_at"
  expected: <2019-06-19T10:16:43.932723Z>
  but was:  <2019-06-19T10:16:43.932Z>
}}`
```
Probably due to JRE or OS change on travis.