### PR TITLE
Update scheduled jobs config format

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
@@ -11,9 +11,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @SpringBootTest
 @TestPropertySource(properties = {
     "scheduling.enabled=true",
-    "tasks.upload-letters-interval-ms=1000",
-    "tasks.mark-letters-posted=*/1 * * * * *",
-    "tasks.stale-letters-report=*/1 * * * * *",
+    "tasks.upload-letters.interval-ms=1000",
+    "tasks.mark-letters-posted.cron=*/1 * * * * *",
+    "tasks.stale-letters-report.cron=*/1 * * * * *",
     "ftp.service-folders[0].service=some_service_name",
     "ftp.service-folders[0].folder=BULKPRINT"
 })

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndWithEncryptionEnabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndWithEncryptionEnabledTest.java
@@ -12,9 +12,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @TestPropertySource(properties = {
     "encryption.enabled=true",
     "scheduling.enabled=true",
-    "tasks.upload-letters-interval-ms=1000",
-    "tasks.mark-letters-posted=*/1 * * * * *",
-    "tasks.stale-letters-report=*/1 * * * * *",
+    "tasks.upload-letters.interval-ms=1000",
+    "tasks.mark-letters-posted.cron=*/1 * * * * *",
+    "tasks.stale-letters-report.cron=*/1 * * * * *",
     "ftp.serviceFolders[0].service=some_service_name",
     "ftp.serviceFolders[0].folder=BULKPRINT"
 })

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
@@ -53,7 +53,7 @@ public class MarkLettersPostedTask {
     }
 
     @SchedulerLock(name = TASK_NAME)
-    @Scheduled(cron = "${tasks.mark-letters-posted}", zone = EUROPE_LONDON)
+    @Scheduled(cron = "${tasks.mark-letters-posted.cron}", zone = EUROPE_LONDON)
     public void run() {
         if (!ftpAvailabilityChecker.isFtpAvailable(LocalTime.now(ZoneId.of(EUROPE_LONDON)))) {
             logger.info("Not processing '{}' task due to FTP downtime window", TASK_NAME);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/StaleLettersTask.java
@@ -35,7 +35,7 @@ public class StaleLettersTask {
     }
 
     @SchedulerLock(name = TASK_NAME)
-    @Scheduled(cron = "${tasks.stale-letters-report}", zone = EUROPE_LONDON)
+    @Scheduled(cron = "${tasks.stale-letters-report.cron}", zone = EUROPE_LONDON)
     public void run() {
         logger.info("Started '{}' task", TASK_NAME);
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -53,7 +53,7 @@ public class UploadLettersTask {
     }
 
     @SchedulerLock(name = TASK_NAME)
-    @Scheduled(fixedDelayString = "${tasks.upload-letters-interval-ms}")
+    @Scheduled(fixedDelayString = "${tasks.upload-letters.interval-ms}")
     public void run() {
         if (!availabilityChecker.isFtpAvailable(now(ZoneId.of(EUROPE_LONDON)).toLocalTime())) {
             logger.info("Not processing '{}' task due to FTP downtime window", TASK_NAME);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,9 +104,12 @@ scheduling:
   lock_at_most_for: ${SCHEDULING_LOCK_AT_MOST_FOR:PT10M} # 10 minutes in ISO-8601
 
 tasks:
-  upload-letters-interval-ms: ${UPLOAD_LETTERS_INTERVAL:30000}
-  mark-letters-posted: ${FTP_REPORTS_CRON:0 30 * * * *}
-  stale-letters-report: ${STALE_LETTERS_REPORT_CRON:0 30 11 * * *}
+  upload-letters:
+    interval-ms: ${UPLOAD_LETTERS_INTERVAL:30000}
+  mark-letters-posted:
+    cron:  ${FTP_REPORTS_CRON:0 30 * * * *}
+  stale-letters-report:
+    cron: ${STALE_LETTERS_REPORT_CRON:0 30 11 * * *}
 
 file-cleanup:
   enabled: ${FILE_CLEANUP_ENABLED:false}


### PR DESCRIPTION
in preparation for adding a new property for 'upload-letters' job that will indicate which fingerprint should be used when searching for letters to upload.