### PR TITLE
Clean up end-to-end test assertions

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -115,14 +115,14 @@ class BaseTest {
                 .atMost(15, SECONDS)
                 .untilAsserted(() -> {
                     List<Letter> letters = repository.findAll();
-                    assertThat(letters).as("letters in DB").hasSize(1);
+                    assertThat(letters).as("Letters in DB").hasSize(1);
                     assertThat(letters.get(0).getStatus()).as("Letter status").isEqualTo(LetterStatus.Posted);
                 });
 
             // Wait for the csv report to be deleted so that we don't stop the FTP server before the send letters
             // task has finished using it.
             await().atMost(15, SECONDS).untilAsserted(
-                () -> assertThat(server.reportFolder.listFiles()).as("CSV report on FTP").isEmpty()
+                () -> assertThat(server.reportFolder.listFiles()).as("CSV reports on FTP").isEmpty()
             );
         }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -97,23 +97,32 @@ class BaseTest {
                 .andReturn();
 
             // Wait for letter to be uploaded.
-            await().atMost(15, SECONDS).untilAsserted(
-                () -> assertThat(validLettersUploaded(server.lettersFolder, isEncryptionEnabled))
-                      .as("No letters uploaded!").isTrue()
-            );
+            await()
+                .atMost(15, SECONDS)
+                .untilAsserted(() -> {
+                    File[] files = server.lettersFolder.listFiles();
+                    assertThat(files)
+                        .as("Files on FTP")
+                        .isNotEmpty()
+                        .allMatch(f -> isValidPdf(isEncryptionEnabled, f));
+                });
 
             // Generate csv report.
             createCsvReport(server);
 
             // The report should be processed and the letter marked posted.
-            await().atMost(15, SECONDS).untilAsserted(
-                () -> assertThat(letterHasBeenPosted()).as("Letter not posted").isTrue()
-            );
+            await()
+                .atMost(15, SECONDS)
+                .untilAsserted(() -> {
+                    List<Letter> letters = repository.findAll();
+                    assertThat(letters.size()).as("Number of letters in DB").isEqualTo(1);
+                    assertThat(letters.get(0).getStatus()).as("Letter status").isEqualTo(LetterStatus.Posted);
+                });
 
             // Wait for the csv report to be deleted so that we don't stop the FTP server before the send letters
             // task has finished using it.
             await().atMost(15, SECONDS).untilAsserted(
-                () -> assertThat(server.reportFolder.listFiles()).as("CSV reports not deleted!").isEmpty()
+                () -> assertThat(server.reportFolder.listFiles()).as("CSV report on FTP").isEmpty()
             );
         }
 
@@ -148,25 +157,12 @@ class BaseTest {
         return Resources.toString(Resources.getResource(fileName), Charsets.UTF_8);
     }
 
-    private boolean letterHasBeenPosted() {
-        List<Letter> letters = repository.findAll();
-        return letters.size() == 1 && letters.get(0).getStatus() == LetterStatus.Posted;
-    }
-
     private void createCsvReport(LocalSftpServer server) throws IOException {
         try (Stream<UUID> letterIds = Arrays.stream(server.lettersFolder.list())
             .map(FileNameHelper::extractIdFromPdfName)) {
 
             CsvReportWriter.writeReport(letterIds, server.reportFolder);
         }
-    }
-
-    private boolean validLettersUploaded(File folder, boolean isEncryptionEnabled) {
-        if (folder.listFiles().length == 0) {
-            return false;
-        }
-        return Arrays.stream(folder.listFiles())
-            .allMatch(f -> isValidPdf(isEncryptionEnabled, f));
     }
 
     private boolean isValidPdf(boolean isEncryptionEnabled, File file) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -100,8 +100,7 @@ class BaseTest {
             await()
                 .atMost(15, SECONDS)
                 .untilAsserted(() -> {
-                    File[] files = server.lettersFolder.listFiles();
-                    assertThat(files)
+                    assertThat(server.lettersFolder.listFiles())
                         .as("Files on FTP")
                         .isNotEmpty()
                         .allMatch(f -> isValidPdf(isEncryptionEnabled, f));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -115,7 +115,7 @@ class BaseTest {
                 .atMost(15, SECONDS)
                 .untilAsserted(() -> {
                     List<Letter> letters = repository.findAll();
-                    assertThat(letters.size()).as("Number of letters in DB").isEqualTo(1);
+                    assertThat(letters).as("letters in DB").hasSize(1);
                     assertThat(letters.get(0).getStatus()).as("Letter status").isEqualTo(LetterStatus.Posted);
                 });
 


### PR DESCRIPTION
Those tests have been failing on my 'speed up marking as posted' branch with annoying and unclear
```
Expecting:
<false>
to be equal to:
<true>
```
messages.

Now it will say that letter status was expected to be 'Posted' but was 'Uploaded' etc.