### PR TITLE
Hotfix `jackson-databind` 2.9.9 -> 2.9.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,10 +202,8 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
       entry 'mockito-core'
     }
-    // solves CVE-2019-12086
-    // remove once spring manager incorporates this changes
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9') {
-      entry 'jackson-core'
+    // CVE-2019-12814
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.1') {
       entry 'jackson-databind'
     }
   }


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
