### PR TITLE
Update test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,11 +186,12 @@ def versions = [
   mockitoJupiter: '2.27.0',
   pdfbox: '2.0.15',
   reformLogging: '5.0.1',
-  restAssured: '3.3.0',
   shedlock: '2.5.0',
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   springfoxSwagger: '2.9.2'
 ]
+
+ext["rest-assured.version"] = '4.0.0'
 
 dependencyManagement {
   dependencies {
@@ -270,12 +271,12 @@ dependencies {
   integrationTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 
   smokeTestCompile sourceSets.main.runtimeClasspath
-  smokeTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
+  smokeTestCompile group: 'io.rest-assured', name: 'rest-assured'
   smokeTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
   smokeTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 
   functionalTestCompile sourceSets.main.runtimeClasspath
-  functionalTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
+  functionalTestCompile group: 'io.rest-assured', name: 'rest-assured'
   functionalTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
   functionalTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 }

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ sonarqube {
 }
 
 pitest {
-  pitestVersion = '1.4.7'
+  pitestVersion = '1.4.9'
 }
 
 dependencyUpdates.resolutionStrategy = {

--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ jacocoTestReport {
   reports {
     xml.enabled = true
     csv.enabled = false
+    xml.destination = file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
   afterEvaluate {
     getClassDirectories().from = getClassDirectories().files.collect {
@@ -131,12 +132,11 @@ jacocoTestReport {
   }
 }
 
-project.tasks['sonarqube'].dependsOn test, integration
+project.tasks['sonarqube'].dependsOn jacocoTestReport
 sonarqube {
   properties {
     property "sonar.projectName", "Reform :: Send Letter Service 2.0"
-    property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
-    property "sonar.jacoco.itReportPath", "${project.buildDir}/jacoco/integration.exec"
+    property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination.path
     property 'sonar.exclusions', "**/config/**, **/BasicLetterInfo.java"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -182,8 +182,9 @@ repositories {
 def versions = [
   bouncycastle: '1.61',
   flywayV: plugins.getPlugin('org.flywaydb.flyway').class.package.implementationVersion,
-  junit: '5.4.2',
-  mockitoJupiter: '2.27.0',
+  junit: '5.5.0',
+  junitPlatform: '1.5.0',
+  mockitoJupiter: '3.0.0',
   pdfbox: '2.0.15',
   reformLogging: '5.0.1',
   shedlock: '2.5.0',
@@ -252,6 +253,12 @@ dependencies {
   compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: versions.bouncycastle
   compile group: 'org.bouncycastle', name: 'bcpg-jdk15on', version: versions.bouncycastle
 
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
+  testCompile group: 'org.junit.platform', name: 'junit-platform-commons', version: versions.junitPlatform
+  testCompile group: 'org.junit.platform', name: 'junit-platform-engine', version: versions.junitPlatform
+
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
   testCompile group: 'com.icegreen', name: 'greenmail', version: '1.5.10', withoutJunit4
   testCompile group: 'org.apache.commons', name: 'commons-email', version: '1.5'
@@ -260,25 +267,20 @@ dependencies {
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: versions.mockitoJupiter
   testCompile group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.24.0', withoutJunit4
 
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
-
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath
   integrationTestCompile group: 'org.apache.sshd', name: 'sshd-scp', version: '2.3.0'
   integrationTestCompile group: 'org.apache.sshd', name: 'sshd-sftp', version: '2.3.0'
   integrationTestCompile group: 'org.testcontainers', name: 'postgresql', version: '1.11.4'
   integrationTestCompile group: 'org.awaitility', name: 'awaitility', version: '3.1.6'
-  integrationTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 
   smokeTestCompile sourceSets.main.runtimeClasspath
+  smokeTestCompile sourceSets.test.runtimeClasspath
   smokeTestCompile group: 'io.rest-assured', name: 'rest-assured'
-  smokeTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
-  smokeTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 
   functionalTestCompile sourceSets.main.runtimeClasspath
+  functionalTestCompile sourceSets.test.runtimeClasspath
   functionalTestCompile group: 'io.rest-assured', name: 'rest-assured'
-  functionalTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, withoutJunit4
-  functionalTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
 }
 
 mainClassName = 'uk.gov.hmcts.reform.sendletter.Application'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
 
+    <suppress>
+        <notes><![CDATA[No fix available]]></notes>
+        <gav regex="true">^org\.apache\.sling:org\.apache\.sling\.javax\.activation:0\.1\.0$</gav>
+        <cve>CVE-2016-5394</cve>
+        <cve>CVE-2016-6798</cve>
+    </suppress>
+
     <!-- spring security -->
     <suppress>
         <notes><![CDATA[No fix is available]]></notes>


### PR DESCRIPTION
### Change description ###

Over time few dependencies were left behind. Recent merge #490 did not include `scp`. Perhaps because dependency manager has enlisted as previous version being latest.

`Rest-assured` has been postponed until manual intervention. Need to register version with extension to make dependencies properly inject.

Another recent development occurred: sonarqube deprecations

Lastly, pitest. Not a frequent tool but it still exists somewhere and, perhaps, QA is using it. Or can use it

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
