### PR TITLE
Remove unnecessary letter count metric in upload task

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.exception.FtpException;
 import uk.gov.hmcts.reform.sendletter.helper.FtpHelper;
-import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.LetterService;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
@@ -34,8 +33,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -52,9 +49,6 @@ class UploadLettersTaskTest {
     private FtpAvailabilityChecker availabilityChecker;
 
     @Mock ServiceFolderMapping serviceFolderMapping;
-
-    @Mock
-    private AppInsights insights;
 
     private LetterService letterService;
 
@@ -82,8 +76,7 @@ class UploadLettersTaskTest {
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
             availabilityChecker,
             serviceFolderMapping,
-            null,
-            insights
+            null
         );
 
         // Invoke the upload job.
@@ -103,8 +96,6 @@ class UploadLettersTaskTest {
             assertThat(l.getPrintedAt()).isNull();
             assertThat(l.getFileContent()).isNotNull();
         }
-
-        verify(insights).trackUploadedLetters(1);
     }
 
     @Test
@@ -120,8 +111,7 @@ class UploadLettersTaskTest {
             FtpHelper.getFailingClient(LocalSftpServer.port),
             availabilityChecker,
             serviceFolderMapping,
-            null,
-            insights
+            null
         );
 
         // and
@@ -142,8 +132,6 @@ class UploadLettersTaskTest {
             assertThat(l.getSentToPrintAt()).isNull();
             assertThat(l.getFileContent()).isNotNull();
         }
-
-        verify(insights, never()).trackUploadedLetters(0);
     }
 
     @Test
@@ -158,15 +146,13 @@ class UploadLettersTaskTest {
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
             availabilityChecker,
             serviceFolderMapping,
-            null,
-            insights
+            null
         );
 
         try (LocalSftpServer server = LocalSftpServer.create()) {
             task.run();
         }
         assertThat(repository.findByStatus(LetterStatus.Uploaded)).hasSize(letterCount);
-        verify(insights).trackUploadedLetters(letterCount);
     }
 
     @Test
@@ -189,8 +175,7 @@ class UploadLettersTaskTest {
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
             availabilityChecker,
             serviceFolderMapping,
-            fingerprint,
-            insights
+            fingerprint
         );
 
         // when

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/logging/AppInsights.java
@@ -37,8 +37,6 @@ public class AppInsights {
 
     static final String LETTER_PRINT_REPORT = "LetterPrintReportReceived";
 
-    static final String LETTER_UPLOAD_FOR_PRINT = "LetterUploadedForPrint";
-
     static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     private final TelemetryClient telemetryClient;
@@ -172,11 +170,5 @@ public class AppInsights {
             ImmutableMap.of("isReportParsedFully", BooleanUtils.toStringYesNo(report.allRowsParsed)),
             ImmutableMap.of("reportSize", (double) report.statuses.size())
         );
-    }
-
-    // metrics
-
-    public void trackUploadedLetters(int lettersUploaded) {
-        telemetryClient.trackMetric(LETTER_UPLOAD_FOR_PRINT, lettersUploaded);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
-import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
@@ -39,22 +38,19 @@ public class UploadLettersTask {
     private final IFtpAvailabilityChecker availabilityChecker;
     private final ServiceFolderMapping serviceFolderMapping;
     private final String keyFingerprint; // only letters with this fingerprint will be sent
-    private final AppInsights insights;
 
     public UploadLettersTask(
         LetterRepository repo,
         FtpClient ftp,
         IFtpAvailabilityChecker availabilityChecker,
         ServiceFolderMapping serviceFolderMapping,
-        @Value("${tasks.upload-letters.key-fingerprint}") String keyFingerprint,
-        AppInsights insights
+        @Value("${tasks.upload-letters.key-fingerprint}") String keyFingerprint
     ) {
         this.repo = repo;
         this.ftp = ftp;
         this.availabilityChecker = availabilityChecker;
         this.serviceFolderMapping = serviceFolderMapping;
         this.keyFingerprint = keyFingerprint;
-        this.insights = insights;
     }
 
     @SchedulerLock(name = TASK_NAME)
@@ -84,10 +80,6 @@ public class UploadLettersTask {
 
                 return uploaded;
             });
-        }
-
-        if (counter > 0) {
-            insights.trackUploadedLetters(counter);
         }
 
         logger.info("Completed '{}' task. Uploaded {} letters", TASK_NAME, counter);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
@@ -123,11 +123,4 @@ class AppInsightsTest {
             ImmutableMap.of("reportSize", 0.0)
         );
     }
-
-    @Test
-    void should_track_metric_of_letter_amount_sent_to_print() {
-        insights.trackUploadedLetters(123);
-
-        verify(telemetry).trackMetric(AppInsights.LETTER_UPLOAD_FOR_PRINT, 123.0);
-    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
-import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
@@ -58,9 +57,6 @@ class UploadLettersTaskTest {
 
     @Mock
     private ServiceFolderMapping serviceFolderMapping;
-
-    @Mock
-    private AppInsights insights;
 
     private ArgumentCaptor<FileToSend> captureFileToSend = ArgumentCaptor.forClass(FileToSend.class);
 
@@ -228,8 +224,7 @@ class UploadLettersTaskTest {
             ftpClient,
             availabilityChecker,
             serviceFolderMapping,
-            fingerprint,
-            insights
+            fingerprint
         );
     }
 }


### PR DESCRIPTION
### Change description ###

The metric can be extracted from the following log (check source code).

Tiny victory achieved - removed direct dependency of `AppInsights` in the uploader task

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
