### PR TITLE
Remove FTP availability checker from tasks

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/EndToEndTest.java
@@ -42,4 +42,13 @@ class EndToEndTest extends BaseTest {
             IS_ENCRYPTION_ENABLED
         );
     }
+
+    @Test
+    void should_not_upload_letter_due_to_ftp_downtime() throws Throwable {
+        request_to_upload_during_ftp_downtime(post("/letters")
+            .header("ServiceAuthorization", "auth-header-value")
+            .contentType(MediaTypes.LETTER_V2)
+            .content(readResource("letter-with-pdf.json"))
+        );
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTaskTest.java
@@ -15,11 +15,9 @@ import uk.gov.hmcts.reform.sendletter.model.ParsedReport;
 import uk.gov.hmcts.reform.sendletter.services.LetterDataAccessService;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
 import uk.gov.hmcts.reform.sendletter.services.ReportParser;
-import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import uk.gov.hmcts.reform.sendletter.util.CsvReportWriter;
 
-import java.time.LocalTime;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 
@@ -27,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
@@ -42,7 +39,6 @@ class MarkLettersPostedTaskTest {
     private EntityManager entityManager;
 
     ReportParser parser = new ReportParser();
-    FtpAvailabilityChecker checker = mock(FtpAvailabilityChecker.class);
     AppInsights insights = mock(AppInsights.class);
 
     @BeforeEach
@@ -57,13 +53,11 @@ class MarkLettersPostedTaskTest {
         letter.setStatus(LetterStatus.Uploaded);
         repository.saveAndFlush(letter);
 
-        when(checker.isFtpAvailable(any(LocalTime.class))).thenReturn(true);
         try (LocalSftpServer server = LocalSftpServer.create()) {
             FtpClient client = FtpHelper.getSuccessfulClient(LocalSftpServer.port);
             MarkLettersPostedTask task = new MarkLettersPostedTask(
                 dataAccessService,
                 client,
-                checker,
                 parser,
                 insights
             );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -17,14 +17,12 @@ import uk.gov.hmcts.reform.sendletter.helper.FtpHelper;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.services.LetterService;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
-import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.ServiceFolderMapping;
 import uk.gov.hmcts.reform.sendletter.services.pdf.DuplexPreparator;
 import uk.gov.hmcts.reform.sendletter.services.pdf.PdfCreator;
 import uk.gov.hmcts.reform.sendletter.services.zip.Zipper;
 
 import java.io.File;
-import java.time.LocalTime;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -48,9 +46,6 @@ class UploadLettersTaskTest {
     @Autowired
     private EntityManager entityManager;
 
-    @Mock
-    private FtpAvailabilityChecker availabilityChecker;
-
     @Mock ServiceFolderMapping serviceFolderMapping;
 
     @Mock
@@ -60,7 +55,6 @@ class UploadLettersTaskTest {
 
     @BeforeEach
     void setUp() {
-        when(availabilityChecker.isFtpAvailable(any(LocalTime.class))).thenReturn(true);
         when(serviceFolderMapping.getFolderFor(any())).thenReturn(Optional.of(LocalSftpServer.SERVICE_FOLDER));
 
         this.letterService = new LetterService(
@@ -80,7 +74,6 @@ class UploadLettersTaskTest {
         UploadLettersTask task = new UploadLettersTask(
             repository,
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
-            availabilityChecker,
             serviceFolderMapping,
             null,
             insights
@@ -118,7 +111,6 @@ class UploadLettersTaskTest {
         UploadLettersTask task = new UploadLettersTask(
             repository,
             FtpHelper.getFailingClient(LocalSftpServer.port),
-            availabilityChecker,
             serviceFolderMapping,
             null,
             insights
@@ -156,7 +148,6 @@ class UploadLettersTaskTest {
         UploadLettersTask task = new UploadLettersTask(
             repository,
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
-            availabilityChecker,
             serviceFolderMapping,
             null,
             insights
@@ -187,7 +178,6 @@ class UploadLettersTaskTest {
         UploadLettersTask task = new UploadLettersTask(
             repository,
             FtpHelper.getSuccessfulClient(LocalSftpServer.port),
-            availabilityChecker,
             serviceFolderMapping,
             fingerprint,
             insights

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/FtpConstraint.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/FtpConstraint.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.sendletter.tasks;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Restriction for scheduled tasks which may impact FTP downtime rule.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface FtpConstraint {
+
+    /**
+     * Schedule name.
+     */
+    String name();
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTask.java
@@ -51,6 +51,7 @@ public class MarkLettersPostedTask {
         this.insights = insights;
     }
 
+    @FtpConstraint(name = TASK_NAME)
     @SchedulerLock(name = TASK_NAME)
     @Scheduled(cron = "${tasks.mark-letters-posted.cron}", zone = EUROPE_LONDON)
     public void run() {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -57,6 +57,7 @@ public class UploadLettersTask {
         this.insights = insights;
     }
 
+    @FtpConstraint(name = TASK_NAME)
     @SchedulerLock(name = TASK_NAME)
     @Scheduled(fixedDelayString = "${tasks.upload-letters.interval-ms}")
     public void run() {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/logging/AppInsightsTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.sendletter.entity.BasicLetterInfo;
 import uk.gov.hmcts.reform.sendletter.model.LetterPrintStatus;
 import uk.gov.hmcts.reform.sendletter.model.ParsedReport;
+import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -46,6 +47,9 @@ class AppInsightsTest {
     @Mock
     private TelemetryClient telemetry;
 
+    @Mock
+    private IFtpAvailabilityChecker ftpAvailabilityChecker;
+
     private AppInsights insights;
 
     private final TelemetryContext context = new TelemetryContext();
@@ -54,7 +58,7 @@ class AppInsightsTest {
     void setUp() {
         context.setInstrumentationKey("some-key");
         when(telemetry.getContext()).thenReturn(context);
-        insights = new AppInsights(telemetry);
+        insights = new AppInsights(telemetry, ftpAvailabilityChecker);
     }
 
     @AfterEach

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/MarkLettersPostedTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.Report;
 import uk.gov.hmcts.reform.sendletter.services.LetterDataAccessService;
 import uk.gov.hmcts.reform.sendletter.services.ReportParser;
-import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 
 import java.time.LocalDateTime;
@@ -33,7 +32,6 @@ class MarkLettersPostedTest {
 
     @Mock LetterDataAccessService dataAccessService;
     @Mock FtpClient ftpClient;
-    @Mock FtpAvailabilityChecker availabilityChecker;
     @Mock ReportParser parser;
     @Mock AppInsights insights;
 
@@ -41,7 +39,7 @@ class MarkLettersPostedTest {
 
     @BeforeEach
     void setup() {
-        task = new MarkLettersPostedTask(dataAccessService, ftpClient, availabilityChecker, parser, insights);
+        task = new MarkLettersPostedTask(dataAccessService, ftpClient, parser, insights);
     }
 
     @Test
@@ -50,7 +48,6 @@ class MarkLettersPostedTest {
         UUID known = UUID.randomUUID();
         UUID unknown = UUID.randomUUID();
 
-        given(availabilityChecker.isFtpAvailable(any())).willReturn(true);
         given(ftpClient.downloadReports())
             .willReturn(singletonList(new Report(filePath, null)));
         given(parser.parse(any()))
@@ -73,8 +70,6 @@ class MarkLettersPostedTest {
         final String reportName = "report.csv";
         final boolean allParsed = true;
 
-        given(availabilityChecker.isFtpAvailable(any())).willReturn(true);
-
         given(ftpClient.downloadReports())
             .willReturn(singletonList(new Report(reportName, null)));
 
@@ -95,8 +90,6 @@ class MarkLettersPostedTest {
         final String reportName = "report.csv";
         final boolean allParsed = false;
 
-        given(availabilityChecker.isFtpAvailable(any())).willReturn(true);
-
         given(ftpClient.downloadReports())
             .willReturn(singletonList(new Report(reportName, null)));
 
@@ -110,16 +103,5 @@ class MarkLettersPostedTest {
 
         // then
         verify(ftpClient, never()).deleteReport(anyString());
-    }
-
-    @Test
-    void should_not_attempt_to_download_reports_during_ftp_downtime() {
-        given(availabilityChecker.isFtpAvailable(any())).willReturn(false);
-
-        // when
-        task.run();
-
-        // then
-        verify(ftpClient, never()).downloadReports();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -226,7 +226,6 @@ class UploadLettersTaskTest {
         return new UploadLettersTask(
             repo,
             ftpClient,
-            availabilityChecker,
             serviceFolderMapping,
             fingerprint,
             insights


### PR DESCRIPTION
### Change description ###

Replace with annotation which is dealt in scheduled wrapped task - present already for all schedules. Just execute check in case annotation is present.

- Transparency in tasks
- Single point of check
- Less mockery in tests

P.S. Maybe could use `@FtpDowntime` annotation name instead of `@FtpConstraint` 🤔

Important reminder! This is suggestion PR. Review/Approve as you will and if thumbed up - can proceed further from here

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
