### PR TITLE
Bumped Jackson databind version to resolve CVE-2019-14379

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ dependencyManagement {
       entry 'mockito-core'
     }
     // CVE-2019-12814
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.2') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.3') {
       entry 'jackson-databind'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ dependencyManagement {
       entry 'mockito-core'
     }
     // CVE-2019-12814
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.1') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.2') {
       entry 'jackson-databind'
     }
   }


### PR DESCRIPTION
- Resolves CVE-2019-14379