### PR TITLE
Remove output of vault values - not needed

### DIFF
--- a/charts/rpe-send-letter-service/values.template.yaml
+++ b/charts/rpe-send-letter-service/values.template.yaml
@@ -33,10 +33,9 @@ java:
     "rpe-send-letter":
       resourceGroup: rpe-send-letter-service
       secrets:
-        - test-s2s-secret
-        - test-ftp-user
-        - test-ftp-private-key
-        - test-ftp-public-key
+        - ftp-user
+        - ftp-private-key
+        - ftp-public-key
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,11 +1,3 @@
-output "vaultUri" {
-  value = "${module.send-letter-key-vault.key_vault_uri}"
-}
-
-output "vaultName" {
-  value = "${module.send-letter-key-vault.key_vault_name}"
-}
-
 output "microserviceName" {
   value = "${var.component}"
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -195,6 +195,12 @@ public class FtpClient {
         ssh.addHostKeyVerifier(configProperties.getFingerprint());
         ssh.connect(configProperties.getHostname(), configProperties.getPort());
 
+        // DEBUG!
+        logger.warn("USER: {}", configProperties.getUsername());
+        logger.warn("PRIVATE KEY: {}", configProperties.getPrivateKey());
+        logger.warn("PUBLIC KEY: {}", configProperties.getPublicKey());
+        // END DEBUG
+
         ssh.authPublickey(
             configProperties.getUsername(),
             ssh.loadKeys(


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Update Jenkinsfiles to solve deprecated vault sets](https://tools.hmcts.net/jira/browse/BPS-775)

### Change description ###

Populating `vaultName` and `vaultUri` breaks the terraform apply step overriding vault names defined in Jenkinsfile config

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
