### PR TITLE
Fix pipelines: PR, master

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -15,9 +15,9 @@ secrets = [
     secret('microservicekey-send-letter-tests', 'TEST_S2S_SECRET')
   ],
   'rpe-send-letter-${env}': [
-    secret('test-ftp-user', 'TEST_FTP_USER'),
-    secret('test-ftp-private-key', 'TEST_FTP_PRIVATE_KEY'),
-    secret('test-ftp-public-key', 'TEST_FTP_PUBLIC_KEY')
+    secret('ftp-user', 'TEST_FTP_USER'),
+    secret('ftp-private-key', 'TEST_FTP_PRIVATE_KEY'),
+    secret('ftp-public-key', 'TEST_FTP_PUBLIC_KEY')
   ]
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -6,9 +6,9 @@ secrets = [
     secret('test-s2s-secret', 'TEST_S2S_SECRET')
   ],
   'rpe-send-letter-${env}': [
-    secret('test-ftp-user', 'TEST_FTP_USER'),
-    secret('test-ftp-private-key', 'TEST_FTP_PRIVATE_KEY'),
-    secret('test-ftp-public-key', 'TEST_FTP_PUBLIC_KEY')
+    secret('ftp-user', 'TEST_FTP_USER'),
+    secret('ftp-private-key', 'TEST_FTP_PRIVATE_KEY'),
+    secret('ftp-public-key', 'TEST_FTP_PUBLIC_KEY')
   ]
 ]
 

--- a/charts/rpe-send-letter-service/values.template.yaml
+++ b/charts/rpe-send-letter-service/values.template.yaml
@@ -30,13 +30,12 @@ java:
     # mails
     SPRING_MAIL_HOST: "false"
   keyVaults:
-    "rpe-send-letter":
+    rpe-send-letter:
       resourceGroup: rpe-send-letter-service
       secrets:
-        - test-s2s-secret
-        - test-ftp-user
-        - test-ftp-private-key
-        - test-ftp-public-key
+        - ftp-user
+        - ftp-private-key
+        - ftp-public-key
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,11 +1,3 @@
-output "vaultUri" {
-  value = "${module.send-letter-key-vault.key_vault_uri}"
-}
-
-output "vaultName" {
-  value = "${module.send-letter-key-vault.key_vault_name}"
-}
-
 output "microserviceName" {
   value = "${var.component}"
 }

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -5,8 +5,7 @@ spring:
       prefixed: true
       paths: /mnt/secrets/rpe-send-letter
       aliases:
-        rpe-send-letter.test-s2s-secret: S2S_SECRET
-        rpe-send-letter.test-ftp-user: FTP_USER
-        rpe-send-letter.test-ftp-private-key: FTP_PRIVATE_KEY
-        rpe-send-letter.test-ftp-public-key: FTP_PUBLIC_KEY
+        rpe-send-letter.ftp-user: FTP_USER
+        rpe-send-letter.ftp-private-key: FTP_PRIVATE_KEY
+        rpe-send-letter.ftp-public-key: FTP_PUBLIC_KEY
         rpe-send-letter.send-letter-service-POSTGRES-PASS: LETTER_TRACKING_DB_PASSWORD


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Update Jenkinsfiles to solve deprecated vault sets](https://tools.hmcts.net/jira/browse/BPS-775)

### Change description ###

After #516 master pipeline broke due to vault outputs being present (https://github.com/hmcts/send-letter-service/commit/f40b4675415d538cee523eda4e30c9c7e53d0788). PRs fail due to reference to `test-` secrets. Shouldn't need to refer to any additional duplicate config and named with `test-*`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
