### PR TITLE
Fix pipeline db migration step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG APP_INSIGHTS_AGENT_VERSION=2.3.1
+ARG APP_INSIGHTS_AGENT_VERSION=2.3.1-SNAPSHOT
 
 FROM hmctspublic.azurecr.io/base/java:openjdk-8-distroless-1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG APP_INSIGHTS_AGENT_VERSION=2.3.1
 FROM hmctspublic.azurecr.io/base/java:openjdk-8-distroless-1.0
 
 COPY lib/applicationinsights-agent-2.3.1-SNAPSHOT.jar lib/AI-Agent.xml /opt/app/
-FROM hmcts/cnp-java-base:openjdk-8u191-jre-alpine3.9-1.0
 
 COPY build/libs/send-letter-service.jar /opt/app/
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -51,7 +51,7 @@ withPipeline(type , product, component) {
     builder.gradle('integration')
   }
 
-  enableDbMigration()
+  enableDbMigration('rpe-send-letter')
   enableSlackNotifications(channel)
   enableDockerBuild()
   installCharts()

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,5 +1,5 @@
 #!groovy
-@Library("Infrastructure")
+@Library("Infrastructure@feature/separate-vault-value-for-db-migration")
 
 secrets = [
   's2s-${env}': [
@@ -36,7 +36,7 @@ properties([
 def channel = '#bsp-build-notices'
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
-  enableDbMigration()
+  enableDbMigration('rpe-send-letter')
   enableSlackNotifications(channel)
 
   loadVaultSecrets(secrets)

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,5 +1,5 @@
 #!groovy
-@Library("Infrastructure@feature/separate-vault-value-for-db-migration")
+@Library("Infrastructure")
 
 secrets = [
   's2s-${env}': [

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -3,7 +3,7 @@
 
 secrets = [
   's2s-${env}': [
-    secret('test-s2s-secret', 'TEST_S2S_SECRET')
+    secret('microservicekey-send-letter-tests', 'TEST_S2S_SECRET')
   ],
   'rpe-send-letter-${env}': [
     secret('ftp-user', 'TEST_FTP_USER'),


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Update Jenkinsfiles to solve deprecated vault sets](https://tools.hmcts.net/jira/browse/BPS-775)

### Change description ###

`enableDbMigration` was using output value of `vaultName` which is suppose to be deprecated. Patch applied and function now accepts vault name should you choose to use this step in your pipeline.

During testing of this feature, fixed parameterised Jenkinsfile which had wrong s2s key name enlisted. That's a **bonus** for this PR

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
