### PR TITLE
Update deprecated chart template usage

### DIFF
--- a/charts/rpe-send-letter-service/Chart.yaml
+++ b/charts/rpe-send-letter-service/Chart.yaml
@@ -1,6 +1,6 @@
 name: rpe-send-letter-service
 home: https://github.com/hmcts/send-letter-service
-version: 0.0.6
+version: 0.0.7
 description: HMCTS Send letter service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/rpe-send-letter-service/requirements.yaml
+++ b/charts/rpe-send-letter-service/requirements.yaml
@@ -2,8 +2,3 @@ dependencies:
   - name: java
     version: ~2.3.1
     repository: '@hmctspublic'
-  - name: postgresql
-    version: ~2.7.10
-    repository: '@stable'
-    tags:
-      - postgresql-pod

--- a/charts/rpe-send-letter-service/requirements.yaml
+++ b/charts/rpe-send-letter-service/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: java
-    version: ~2.2.2
+    version: ~2.3.1
     repository: '@hmctspublic'
   - name: postgresql
     version: ~2.7.10

--- a/charts/rpe-send-letter-service/values.aat.template.yaml
+++ b/charts/rpe-send-letter-service/values.aat.template.yaml
@@ -4,7 +4,6 @@ java:
       resourceGroup: rpe-send-letter-service
       secrets:
         - service-POSTGRES-PASS
-        - test-s2s-secret
-        - test-ftp-user
-        - test-ftp-private-key
-        - test-ftp-public-key
+        - ftp-user
+        - ftp-private-key
+        - ftp-public-key

--- a/charts/rpe-send-letter-service/values.aat.template.yaml
+++ b/charts/rpe-send-letter-service/values.aat.template.yaml
@@ -1,0 +1,10 @@
+java:
+  keyVaults:
+    "rpe-send-letter":
+      resourceGroup: rpe-send-letter-service
+      secrets:
+        - service-POSTGRES-PASS
+        - test-s2s-secret
+        - test-ftp-user
+        - test-ftp-private-key
+        - test-ftp-public-key

--- a/charts/rpe-send-letter-service/values.aat.template.yaml
+++ b/charts/rpe-send-letter-service/values.aat.template.yaml
@@ -1,9 +1,0 @@
-java:
-  keyVaults:
-    "rpe-send-letter":
-      resourceGroup: rpe-send-letter-service
-      secrets:
-        - service-POSTGRES-PASS
-        - ftp-user
-        - ftp-private-key
-        - ftp-public-key

--- a/charts/rpe-send-letter-service/values.preview.template.yaml
+++ b/charts/rpe-send-letter-service/values.preview.template.yaml
@@ -1,0 +1,6 @@
+java:
+  # Don't modify below here
+  image: ${IMAGE_NAME}
+  ingressHost: ${SERVICE_FQDN}
+postgresql:
+  enabled: true

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -27,5 +27,4 @@ java:
     # mails
     SPRING_MAIL_HOST: "false"
   # Don't modify below here
-  image: ${IMAGE_NAME}
-  ingressHost: ${SERVICE_FQDN}
+  image: 'https://hmctspublic.azurecr.io/rpe-send-letter/service:latest'

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -26,13 +26,6 @@ java:
     FTP_DOWNTIME_TO: "23:59"
     # mails
     SPRING_MAIL_HOST: "false"
-  keyVaults:
-    rpe-send-letter:
-      resourceGroup: rpe-send-letter-service
-      secrets:
-        - ftp-user
-        - ftp-private-key
-        - ftp-public-key
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -2,13 +2,12 @@ java:
   applicationPort: 8485
   environment:
     # db
-    LETTER_TRACKING_DB_NAME: letter_tracking
-    LETTER_TRACKING_DB_HOST: ${SERVICE_NAME}-postgresql
-    LETTER_TRACKING_DB_PORT: "5432"
-    LETTER_TRACKING_DB_USER_NAME: letterservice
-    LETTER_TRACKING_DB_PASSWORD: letterpassword
+    LETTER_TRACKING_DB_HOST: "{{ .Release.Name }}-postgresql"
+    LETTER_TRACKING_DB_NAME: "{{ .Values.postgresql.postgresqlDatabase}}"
+    LETTER_TRACKING_DB_USER_NAME: "{{ .Values.postgresql.postgresqlUsername}}"
+    LETTER_TRACKING_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     # db - migration
-    FLYWAY_URL: "jdbc:postgresql://${SERVICE_NAME}-postgresql:5432/letter_tracking"
+    FLYWAY_URL: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase}}"
     FLYWAY_NOOP_STRATEGY: "false"
     # encryption
     ENCRYPTION_ENABLED: "false"
@@ -37,14 +36,3 @@ java:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-
-postgresql:
-  postgresqlUsername: letterservice
-  postgresqlPassword: letterpassword
-  postgresqlDatabase: letter_tracking
-  service:
-    port: 5432
-  persistence:
-    enabled: false
-tags:
-  postgresql-pod: true

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -4,7 +4,6 @@ java:
     rpe-send-letter:
       resourceGroup: rpe-send-letter-service
       secrets:
-        - service-POSTGRES-PASS
         - ftp-user
         - ftp-private-key
         - ftp-public-key

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -16,8 +16,6 @@ java:
     # schedules
     SCHEDULING_ENABLED: "true"
     # inherited
-    LOGBACK_REQUIRE_ALERT_LEVEL: "false"
-    LOGBACK_REQUIRE_ERROR_CODE: "false"
     S2S_NAME: "send_letter_tests"
     S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
     FTP_HOSTNAME: "cmseft.services.xerox.com"

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -1,5 +1,13 @@
 java:
   applicationPort: 8485
+  keyVaults:
+    rpe-send-letter:
+      resourceGroup: rpe-send-letter-service
+      secrets:
+        - service-POSTGRES-PASS
+        - ftp-user
+        - ftp-private-key
+        - ftp-public-key
   environment:
     # db
     LETTER_TRACKING_DB_HOST: "{{ .Release.Name }}-postgresql"

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -8,4 +8,3 @@ spring:
         rpe-send-letter.ftp-user: FTP_USER
         rpe-send-letter.ftp-private-key: FTP_PRIVATE_KEY
         rpe-send-letter.ftp-public-key: FTP_PUBLIC_KEY
-        rpe-send-letter.send-letter-service-POSTGRES-PASS: LETTER_TRACKING_DB_PASSWORD


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Update send letter service chart to solve deprecation](https://tools.hmcts.net/jira/browse/BPS-779)

### Change description ###

Usage of values.template.yaml is deprecated and TTL is until the end of this week

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
