### PR TITLE
Remove output of `microserviceName`

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,7 +1,3 @@
-output "microserviceName" {
-  value = "${var.component}"
-}
-
 #region Data for tests
 
 output "test_s2s_url" {


### PR DESCRIPTION
### Change description ###

Component is used/preferred in jenkins library anyway - removing this and solving deprecation notice all-together

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
