### PR TITLE
Bump commons-compress 1.18 -> 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,8 @@ dependencies {
   integrationTestCompile sourceSets.test.runtimeClasspath
   integrationTestCompile group: 'org.apache.sshd', name: 'sshd-scp', version: '2.3.0'
   integrationTestCompile group: 'org.apache.sshd', name: 'sshd-sftp', version: '2.3.0'
-  integrationTestCompile group: 'org.testcontainers', name: 'postgresql', version: '1.12.0'
+  integrationTestCompile group: 'org.testcontainers', name: 'postgresql', version: '1.12.0' // remove `commons-compress` once fixed in testcontainers
+  integrationTestCompile group: 'org.apache.commons', name: 'commons-compress', version: '1.19'
   integrationTestCompile group: 'org.awaitility', name: 'awaitility', version: '4.0.0'
 
   smokeTestCompile sourceSets.main.runtimeClasspath


### PR DESCRIPTION
### Change description ###

Used by `testcontainers`. Dependency tree after this change:

```bash
1384-+--- org.testcontainers:postgresql:1.12.0
1385-|    \--- org.testcontainers:jdbc:1.12.0
1386-|         \--- org.testcontainers:database-commons:1.12.0
1387-|              \--- org.testcontainers:testcontainers:1.12.0
1388-|                   +--- junit:junit:4.12
1389-|                   |    \--- org.hamcrest:hamcrest-core:1.3
1390-|                   +--- org.slf4j:slf4j-api:1.7.26
1391-|                   +--- org.jetbrains:annotations:17.0.0
1392-|                   +--- javax.annotation:javax.annotation-api:1.3.2
1393:|                   +--- org.apache.commons:commons-compress:1.18 -> 1.19
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
