### PR TITLE
Remove 'dynamic' version of flyway from `versions` definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,6 @@ repositories {
 
 def versions = [
   bouncycastle: '1.62',
-  flywayV: plugins.getPlugin('org.flywaydb.flyway').class.package.implementationVersion,
   junit: '5.5.1',
   junitPlatform: '1.5.1',
   mockitoJupiter: '3.0.0',
@@ -222,7 +221,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: versions.springBoot
 
-  compile group: 'org.flywaydb', name: 'flyway-core', version: versions.flywayV
+  compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
   compile group: 'org.postgresql', name: 'postgresql', version: '42.2.6'
 
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: versions.shedlock


### PR DESCRIPTION
### Change description ###

There was never a version in flyway gradle plugin defined and spring boot manager picked whichever it has in configs. Which was 5.2.4

Dependabot will try to bump to 6.0.2 (as of now) but it is not compatible with current spring boot 2.1 series ¯\\\_(ツ)_/¯

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
