### PR TITLE
Use of `moj` prefix is deprecated

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -33,7 +33,7 @@ locals {
 }
 
 module "db" {
-  source          = "git@github.com:hmcts/moj-module-postgres?ref=master"
+  source          = "git@github.com:hmcts/cnp-module-postgres?ref=master"
   product         = "${var.product}-${var.component}-db"
   location        = "${var.location_db}"
   env             = "${var.env}"
@@ -46,7 +46,7 @@ module "db" {
 }
 
 module "send-letter-service" {
-  source                 = "git@github.com:hmcts/moj-module-webapp?ref=master"
+  source                 = "git@github.com:hmcts/cnp-module-webapp?ref=master"
   product                = "${var.product}-${var.component}"
   location               = "${var.location_app}"
   env                    = "${var.env}"
@@ -105,7 +105,7 @@ module "send-letter-service" {
 
 # region save DB details to Azure Key Vault
 module "send-letter-key-vault" {
-  source              = "git@github.com:hmcts/moj-module-key-vault?ref=master"
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
   name                = "${local.vaultName}"
   product             = "${var.product}"
   env                 = "${var.env}"


### PR DESCRIPTION
### Change description ###

This was a symlink anyway, using `cnp` instead

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
