### PR TITLE
Split out user auth related IOException for better debug

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ftp/FtpClient.java
@@ -4,6 +4,7 @@ import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.sftp.SFTPFileTransfer;
+import net.schmizz.sshj.userauth.UserAuthException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -175,6 +176,10 @@ public class FtpClient {
             ssh = getSshClient();
 
             return action.apply(ssh.newSFTPClient());
+        } catch (UserAuthException exception) {
+            // action not yet applied. schedule will retry on next run
+            // logging better message as after 3 retries connection was established
+            throw new FtpException("Unable to authenticate.", exception);
         } catch (IOException exc) {
             throw new FtpException("FTP operation failed.", exc);
         } finally {


### PR DESCRIPTION
### Change description ###

This morning we've received 3 instances of exception logs (and email alerts) about Timeout exception. As we were aware some workaround was done for upload task this was actually prior doing any uploads - getting ssh connection established. Timed out while authenticating user. After 3rd failure everything went back to normal.

Reflecting that and though splitting generic `IOException` with separate step which recognises `UserAuthException` and logs appropriate yet short message - similarly as the original catch block statement

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
