### PR TITLE
Bump shedlock 2.5.0 -> 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ def versions = [
   mockitoJupiter: '3.0.0',
   pdfbox: '2.0.16',
   reformLogging: '5.0.1',
-  shedlock: '2.6.0',
+  shedlock: '3.0.0',
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   springfoxSwagger: '2.9.2'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ def versions = [
   mockitoJupiter: '3.0.0',
   pdfbox: '2.0.16',
   reformLogging: '5.0.1',
-  shedlock: '2.5.0',
+  shedlock: '2.6.0',
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   springfoxSwagger: '2.9.2'
 ]


### PR DESCRIPTION
### Change description ###

Aligns with spring boot. Follow references in hmcts/bulk-scan-processor#842 and hmcts/bulk-scan-processor#843

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
