### PR TITLE
Increase max wait time for files to appear on FTP in functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sendletter/FunctionalTestSuite.java
@@ -33,7 +33,7 @@ import java.util.zip.ZipInputStream;
 
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
-import static org.apache.commons.lang.time.DateUtils.addMilliseconds;
+import static org.apache.commons.lang.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.util.DateUtil.now;
@@ -75,9 +75,6 @@ abstract class FunctionalTestSuite {
 
     @Value("${ftp-public-key}")
     private String ftpPublicKey;
-
-    @Value("${max-wait-for-ftp-file-in-ms}")
-    int maxWaitForFtpFileInMs;
 
     @Value("${encryption.enabled}")
     Boolean isEncryptionEnabled;
@@ -211,7 +208,7 @@ abstract class FunctionalTestSuite {
         String letterId,
         BiConsumer<RemoteResourceInfo, SFTPClient> action
     ) throws IOException, InterruptedException {
-        Date waitUntil = addMilliseconds(now(), maxWaitForFtpFileInMs);
+        Date waitUntil = addSeconds(now(), 60);
 
         Boolean fileExists = false;
 

--- a/src/functionalTest/resources/application.properties
+++ b/src/functionalTest/resources/application.properties
@@ -9,5 +9,4 @@ ftp-target-folder=${FTP_TARGET_FOLDER}
 ftp-user=${TEST_FTP_USER}
 ftp-private-key=${TEST_FTP_PRIVATE_KEY}
 ftp-public-key=${TEST_FTP_PUBLIC_KEY}
-max-wait-for-ftp-file-in-ms=45000
 encryption.enabled=${TEST_ENCRYPTION_ENABLED}


### PR DESCRIPTION
From 45 to 60 seconds.
Also simplified it a bit, sorry ;)