### PR TITLE
Upload only one batch of files in single job run

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -132,9 +132,8 @@ class UploadLettersTaskTest {
     }
 
     @Test
-    void should_process_all_letter_batches() throws Exception {
-        // Twice the batch size.
-        int letterCount = 20;
+    void should_process_only_one_batch_of_files_in_single_run() throws Exception {
+        int letterCount = 10;
         IntStream.rangeClosed(1, letterCount).forEach(
             x -> letterService.save(SampleData.letterRequest(), "bulkprint"));
 
@@ -148,6 +147,6 @@ class UploadLettersTaskTest {
         try (LocalSftpServer server = LocalSftpServer.create()) {
             task.run();
         }
-        assertThat(repository.findByStatus(LetterStatus.Uploaded)).hasSize(letterCount);
+        assertThat(repository.findByStatus(LetterStatus.Uploaded)).hasSize(3); // batch size
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -58,23 +58,11 @@ public class UploadLettersTask {
 
         logger.info("Started '{}' task", TASK_NAME);
 
-        // Upload the letters in batches.
-        // With each batch we mark them Uploaded/Skipped so they no longer appear in the query.
         List<Letter> lettersToUpload = repo.findFirst3ByStatus(LetterStatus.Created);
         int counter = 0;
 
         if (!lettersToUpload.isEmpty()) {
-            counter = ftp.runWith(sftpClient -> {
-                int uploaded = uploadLetters(lettersToUpload, sftpClient);
-                List<Letter> letters;
-
-                do {
-                    letters = repo.findFirst3ByStatus(LetterStatus.Created);
-                    uploaded += uploadLetters(letters, sftpClient);
-                } while (!letters.isEmpty());
-
-                return uploaded;
-            });
+            counter = ftp.runWith(sftpClient -> uploadLetters(lettersToUpload, sftpClient));
         }
 
         logger.info("Completed '{}' task. Uploaded {} letters", TASK_NAME, counter);


### PR DESCRIPTION
To prevent racing condition when lock expires and other instances start processing the same letters.