### PR TITLE
Simplify liveness alert check

### DIFF
--- a/infrastructure/liveness-alert.tf
+++ b/infrastructure/liveness-alert.tf
@@ -10,7 +10,6 @@ module "send-letter-service-liveness-alert" {
   app_insights_query = <<EOF
 requests
 | where name == "GET /health" and resultCode != "200"
-| where url contains "send-letter-service"
 EOF
 
   frequency_in_minutes       = 15


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/BPS-933

Removing the `where` clause completely. Send letter consists of a single service currently.