### PR TITLE
Suppress jetty dependencies

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -45,6 +45,18 @@
         <cve>CVE-2016-6497</cve>
     </suppress>
 
+    <suppress until="2020-01-06">
+        <notes><![CDATA[No fix available. Not used by server - comes with wiremock-jre8 used only in integration tests]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-(alpn-conscrypt-server|alpn-server|webapp|security|servlet|server|servlets|alpn-conscrypt-client|http|alpn-client|continuation|xml|util)@9\.4\.22\.v20191022.*$</packageUrl>
+        <cve>CVE-2019-17632</cve>
+    </suppress>
+
+    <suppress until="2020-01-06">
+        <notes><![CDATA[No fix available. Not used by server - comes with wiremock-jre8 used only in integration tests]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-(server|common|hpack)@9\.4\.22\.v20191022.*$</packageUrl>
+        <cve>CVE-2019-17632</cve>
+    </suppress>
+
     <suppress>
         <notes><![CDATA[ file name: handlebars-4.1.2.jar: handlebars-v4.0.4.js ]]></notes>
         <packageUrl regex="true">^pkg:javascript/handlebars\.js@.*$</packageUrl>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,16 +46,6 @@
     </suppress>
 
     <suppress>
-        <notes><![CDATA[
-       file name: wiremock-jre8-2.23.2.jar.
-       This is only used for TESTING purposes.
-   ]]></notes>
-        <filePath regex="true">.*wiremock-jre8-2\.23\.2\.jar.*</filePath>
-        <!-- jquery -->
-        <cve>CVE-2019-11358</cve>
-    </suppress>
-
-    <suppress>
         <notes><![CDATA[ file name: handlebars-4.1.2.jar: handlebars-v4.0.4.js ]]></notes>
         <packageUrl regex="true">^pkg:javascript/handlebars\.js@.*$</packageUrl>
         <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</vulnerabilityName>


### PR DESCRIPTION
### Change description ###

Wiremock pulls in handful of jetty dependencies which just got marked as vulnerable. Not used by server.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
