### PR TITLE
Remove redundant dependency management for tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,10 +203,6 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
       entry 'mockito-core'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.30') {
-      entry 'tomcat-embed-core'
-      entry 'tomcat-embed-websocket'
-    }
     // remove once aligned with testcontainers
     dependencySet(group: 'org.testcontainers', version: '1.12.4') {
       entry 'database-commons'


### PR DESCRIPTION
### Change description ###

Vulnerabilities already solved with latest spring boot updates. Management is redundant now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
