### PR TITLE
Remove deprecated property in chart for preview template

### DIFF
--- a/charts/rpe-send-letter-service/Chart.yaml
+++ b/charts/rpe-send-letter-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: rpe-send-letter-service
 apiVersion: v1
 home: https://github.com/hmcts/send-letter-service
-version: 0.0.9
+version: 0.0.10
 description: HMCTS Send letter service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/rpe-send-letter-service/requirements.yaml
+++ b/charts/rpe-send-letter-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.11.2
+    version: ~2.16.0
     repository: '@hmctspublic'

--- a/charts/rpe-send-letter-service/values.preview.template.yaml
+++ b/charts/rpe-send-letter-service/values.preview.template.yaml
@@ -2,7 +2,6 @@ java:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  aadIdentityName:
   keyVaults:
     rpe-send-letter:
       secrets:


### PR DESCRIPTION
### Change description ###

Recreating #648 

The problem was with too old java chart version. Only from 2.13.* series this is enabled

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
