### PR TITLE
Bump org.springframework.boot from 2.2.4.RELEASE to 2.2.5.RELEASE and remove deprecated chart config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
   id 'org.flywaydb.flyway' version '6.2.4'
-  id 'org.springframework.boot' version '2.2.4.RELEASE'
+  id 'org.springframework.boot' version '2.2.5.RELEASE'
   id 'org.owasp.dependencycheck' version '5.3.0'
   id 'com.github.ben-manes.versions' version '0.28.0'
   id 'org.sonarqube' version '2.8'

--- a/charts/rpe-send-letter-service/Chart.yaml
+++ b/charts/rpe-send-letter-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: rpe-send-letter-service
 apiVersion: v1
 home: https://github.com/hmcts/send-letter-service
-version: 0.0.9
+version: 0.0.10
 description: HMCTS Send letter service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/rpe-send-letter-service/requirements.yaml
+++ b/charts/rpe-send-letter-service/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.11.2
+    version: ~2.16.0
     repository: '@hmctspublic'

--- a/charts/rpe-send-letter-service/values.preview.template.yaml
+++ b/charts/rpe-send-letter-service/values.preview.template.yaml
@@ -2,7 +2,6 @@ java:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  aadIdentityName:
   keyVaults:
     rpe-send-letter:
       secrets:

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,7 @@
     </suppress>
     <suppress>
         <notes><![CDATA[No fix is available]]></notes>
-        <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.2\.1\.RELEASE$</gav>
+        <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.2\.2\.RELEASE$</gav>
         <cve>CVE-2018-1258</cve>
     </suppress>
 


### PR DESCRIPTION

### Change description ###

- This PR includes Dependabot upgrade for springboot.

- Also will need to include removal of deprecated config for preview.

- Suppression updated to include the new crypto jar version.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
