### PR TITLE
Use JDBC lock provider instead of JDBC template 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ dependencies {
   compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
   compile group: 'org.postgresql', name: 'postgresql', version: '42.2.11'
 
-  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: versions.shedlock
+  compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc', version: versions.shedlock
   compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: versions.shedlock
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/SchedulerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/SchedulerConfiguration.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
 import net.javacrumbs.shedlock.core.LockProvider;
-import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.provider.jdbc.JdbcLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -20,6 +20,6 @@ public class SchedulerConfiguration {
 
     @Bean
     public LockProvider lockProvider(DataSource dataSource) {
-        return new JdbcTemplateLockProvider(dataSource);
+        return new JdbcLockProvider(dataSource);
     }
 }


### PR DESCRIPTION
### Change description ###

- JDBC template with latest version of shed lock seems to have some issues with race condition of acquiring lock.

- This is an attempt to see if it fixes it. Processor already uses it and doesn't see any issues.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
