### PR TITLE
Remove has_failed field from response

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,7 @@ Here's what a response body should look like:
     "checksum": "401b30e3b8b5d629635a5c613cdb7919",
     "created_at": "2020-01-12T01:02:03.123Z",
     "sent_to_print_at": "2020-01-13T01:02:03.123Z",
-    "printed_at": "2020-01-14T01:02:03.123Z",
-    "has_failed": false
+    "printed_at": "2020-01-14T01:02:03.123Z"
 }
 ```
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/GetLetterStatusTest.java
@@ -79,8 +79,7 @@ class GetLetterStatusTest {
             .andExpect(jsonPath("$.checksum").value(letter.getChecksum()))
             .andExpect(jsonPath("$.created_at").value(toIso(letter.getCreatedAt())))
             .andExpect(jsonPath("$.sent_to_print_at").isEmpty())
-            .andExpect(jsonPath("$.printed_at").isEmpty())
-            .andExpect(jsonPath("$.has_failed").value(false));
+            .andExpect(jsonPath("$.printed_at").isEmpty());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/LetterStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/LetterStatus.java
@@ -28,17 +28,13 @@ public class LetterStatus {
     @JsonProperty("printed_at")
     public final ZonedDateTime printedAt;
 
-    @JsonProperty("has_failed")
-    public final boolean hasFailed;
-
     public LetterStatus(
         final UUID id,
         final String status,
         final String checksum,
         final ZonedDateTime createdAt,
         final ZonedDateTime sentToPrintAt,
-        final ZonedDateTime printedAt,
-        final boolean hasFailed
+        final ZonedDateTime printedAt
     ) {
         this.id = id;
         this.status = status;
@@ -47,6 +43,5 @@ public class LetterStatus {
         this.createdAt = createdAt;
         this.sentToPrintAt = sentToPrintAt;
         this.printedAt = printedAt;
-        this.hasFailed = hasFailed;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -179,8 +179,7 @@ public class LetterService {
                 letter.getChecksum(),
                 toDateTime(letter.getCreatedAt()),
                 toDateTime(letter.getSentToPrintAt()),
-                toDateTime(letter.getPrintedAt()),
-                letter.isFailed()
+                toDateTime(letter.getPrintedAt())
             ))
             .orElseThrow(() -> new LetterNotFoundException(id));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/sendlettercontroller/GetLetterStatusControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/sendlettercontroller/GetLetterStatusControllerTest.java
@@ -43,7 +43,7 @@ class GetLetterStatusControllerTest {
     @BeforeEach
     void setUp() {
         ZonedDateTime now = ZonedDateTime.of(2000, 2, 12, 1, 2, 3, 123_000_000, ZoneId.systemDefault());
-        letterStatus = new LetterStatus(UUID.randomUUID(), "Created", "some-message-id", now, now, now, false);
+        letterStatus = new LetterStatus(UUID.randomUUID(), "Created", "some-message-id", now, now, now);
     }
 
     @Test
@@ -61,8 +61,7 @@ class GetLetterStatusControllerTest {
                     + "\"checksum\":\"" + letterStatus.checksum + "\","
                     + "\"created_at\":\"2000-02-12T01:02:03.123Z\","
                     + "\"sent_to_print_at\":\"2000-02-12T01:02:03.123Z\","
-                    + "\"printed_at\":\"2000-02-12T01:02:03.123Z\","
-                    + "\"has_failed\": false"
+                    + "\"printed_at\":\"2000-02-12T01:02:03.123Z\""
                     + "}"
             ));
     }


### PR DESCRIPTION
A legacy column in DB, it's always set to `FALSE`.
Judging by requests logged in app insights, this models is never used by the clients.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
