### PR TITLE
Use send letter MI instead of generic RPE MI

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,3 +1,3 @@
 vault_section = "preprod"
 enable_ase = false
-managed_identity_object_id = "74e34a26-d5fd-473a-9ef7-e5e89e228a20"
+managed_identity_object_id = "4c08cb3f-9e6d-46bf-ae33-1b82ae1504af"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1225

### Change description ###

- Mistakenly generic RPE MI was used for send letter which was supposed to used for other rpe services.

- Send letter service has it's own MI so using that one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
