### PR TITLE
Bump log4j 2.12.1 -> 2.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,11 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: versions.mockitoJupiter) {
       entry 'mockito-core'
     }
+    // CVE-2020-9488. remove once dependency is resolved by spring boot logging
+    dependencySet(group: 'org.apache.logging.log4j', version: '2.13.2') {
+      entry 'log4j-to-slf4j'
+      entry 'log4j-api'
+    }
   }
 }
 


### PR DESCRIPTION
### Change description ###

new owasp report: https://nvd.nist.gov/vuln/detail/CVE-2020-9488

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
