### PR TITLE
Configure multiple (2nd) datasource for (spring) application

### DIFF
--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -2,10 +2,10 @@ idam.s2s-auth.url=false
 
 management.endpoints.web.base-path=/
 
-spring.datasource.legacy.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.legacy.jdbc-url=jdbc:tc:postgresql:9.6://localhost/letter_tracking
-spring.datasource.v11.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.v11.jdbc-url=jdbc:tc:postgresql:11://localhost/letter_tracking
+spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/letter_tracking
+spring.datasource-v11.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource-v11.url=jdbc:tc:postgresql:11://localhost/letter_tracking
 
 ftp.hostname: localhost
 ftp.port: 46043

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -4,6 +4,8 @@ management.endpoints.web.base-path=/
 
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/letter_tracking
+spring.datasource-v11.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource-v11.url=jdbc:tc:postgresql:11://localhost/letter_tracking
 
 ftp.hostname: localhost
 ftp.port: 46043

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -2,10 +2,10 @@ idam.s2s-auth.url=false
 
 management.endpoints.web.base-path=/
 
-spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:9.6://localhost/letter_tracking
-spring.datasource-v11.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource-v11.url=jdbc:tc:postgresql:11://localhost/letter_tracking
+spring.datasource.legacy.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource.legacy.jdbc-url=jdbc:tc:postgresql:9.6://localhost/letter_tracking
+spring.datasource.v11.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
+spring.datasource.v11.jdbc-url=jdbc:tc:postgresql:11://localhost/letter_tracking
 
 ftp.hostname: localhost
 ftp.port: 46043

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.sendletter.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    entityManagerFactoryRef = "entityManagerFactory",
+    basePackages = { "uk.gov.hmcts.reform.sendletter.data" }
+)
+public class DbConfiguration {
+
+    @Bean(name = "dataSource")
+    @ConfigurationProperties(prefix = "spring.datasource-v11")
+    public DataSource dataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "entityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+        EntityManagerFactoryBuilder builder,
+        @Qualifier("dataSource") DataSource dataSource
+    ) {
+        return builder
+            .dataSource(dataSource)
+            .packages("uk.gov.hmcts.reform.sendletter.data")
+            .persistenceUnit("main")
+            .build();
+    }
+
+    @Bean(name = "transactionManager")
+    public PlatformTransactionManager transactionManager(
+        @Qualifier("entityManagerFactory") EntityManagerFactory
+            entityManagerFactory
+    ) {
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
@@ -25,6 +26,7 @@ public class DbConfiguration {
 
     @Bean(name = "dataSource")
     @ConfigurationProperties(prefix = "spring.datasource-v11")
+    @FlywayDataSource
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
@@ -25,8 +24,7 @@ import javax.sql.DataSource;
 public class DbConfiguration {
 
     @Bean(name = "dataSource")
-    @ConfigurationProperties(prefix = "spring.datasource-v11")
-    @FlywayDataSource
+    @ConfigurationProperties(prefix = "spring.datasource.v11")
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/DbConfiguration.java
@@ -19,12 +19,13 @@ import javax.sql.DataSource;
 @EnableTransactionManagement
 @EnableJpaRepositories(
     entityManagerFactoryRef = "entityManagerFactory",
+    transactionManagerRef = "transactionManager",
     basePackages = { "uk.gov.hmcts.reform.sendletter.data" }
 )
 public class DbConfiguration {
 
     @Bean(name = "dataSource")
-    @ConfigurationProperties(prefix = "spring.datasource.v11")
+    @ConfigurationProperties(prefix = "spring.datasource-v11")
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
@@ -28,6 +29,7 @@ public class LegacyDbConfiguration {
     @Primary
     @Bean(name = "dataSource-legacy")
     @ConfigurationProperties(prefix = "spring.datasource")
+    @FlywayDataSource
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sendletter.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.flyway.FlywayDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
@@ -28,8 +27,7 @@ public class LegacyDbConfiguration {
 
     @Primary
     @Bean(name = "dataSource-legacy")
-    @ConfigurationProperties(prefix = "spring.datasource")
-    @FlywayDataSource
+    @ConfigurationProperties(prefix = "spring.datasource.legacy")
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.sendletter.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    entityManagerFactoryRef = "entityManagerFactory",
+    basePackages = { "uk.gov.hmcts.reform.sendletter.entity" }
+)
+public class LegacyDbConfiguration {
+
+    @Primary
+    @Bean(name = "dataSource-legacy")
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource dataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Primary
+    @Bean(name = "entityManagerFactory-legacy")
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+        EntityManagerFactoryBuilder builder,
+        @Qualifier("dataSource-legacy") DataSource dataSource
+    ) {
+        return builder
+            .dataSource(dataSource)
+            .packages(LetterRepository.class.getPackageName())
+            .persistenceUnit("legacy")
+            .build();
+    }
+
+    @Primary
+    @Bean(name = "transactionManager-legacy")
+    public PlatformTransactionManager transactionManager(
+        @Qualifier("entityManagerFactory-legacy") EntityManagerFactory
+            entityManagerFactory
+    ) {
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/config/LegacyDbConfiguration.java
@@ -20,14 +20,14 @@ import javax.sql.DataSource;
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(
-    entityManagerFactoryRef = "entityManagerFactory",
+    entityManagerFactoryRef = "entityManagerFactory-legacy",
     basePackages = { "uk.gov.hmcts.reform.sendletter.entity" }
 )
 public class LegacyDbConfiguration {
 
     @Primary
     @Bean(name = "dataSource-legacy")
-    @ConfigurationProperties(prefix = "spring.datasource.legacy")
+    @ConfigurationProperties(prefix = "spring.datasource")
     public DataSource dataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,1 @@
 logging.level.org.hibernate=WARN
-
-spring.datasource.jdbcUrl=${spring.datasource.url}
-spring.datasource-v11.jdbcUrl=${spring.datasource-v11.url}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 logging.level.org.hibernate=WARN
+
+spring.datasource.jdbcUrl=${spring.datasource.url}
+spring.datasource-v11.jdbcUrl=${spring.datasource-v11.url}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,6 +35,21 @@ spring:
       poolName: SendLetterHikariCP
       maxLifetime: 7200000
       connectionTimeout: 30000
+  # same as ^
+  datasource-v11:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST:send-letter-database}:${DB_PORT:5432}/${DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
+    username: ${DB_USER:letterservice}
+    password: ${DB_PASSWORD:}
+    properties:
+      charSet: UTF-8
+    hikari:
+      minimumIdle: 2
+      maximumPoolSize: 10
+      idleTimeout: 10000
+      poolName: SendLetterHikariCP
+      maxLifetime: 7200000
+      connectionTimeout: 30000
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,6 +51,8 @@ spring:
       maxLifetime: 7200000
       connectionTimeout: 30000
   jpa:
+    # so spring can auto-detect different sql dialect for each datasource
+    database: default
     properties:
       hibernate:
         jdbc:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,34 +22,35 @@ spring:
   application:
     name: Send Letter Service
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${LETTER_TRACKING_DB_HOST:send-letter-database}:${LETTER_TRACKING_DB_PORT:5432}/${LETTER_TRACKING_DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
-    username: ${LETTER_TRACKING_DB_USER_NAME:letterservice}
-    password: ${LETTER_TRACKING_DB_PASSWORD:}
-    properties:
-      charSet: UTF-8
-    hikari:
-      minimumIdle: 2
-      maximumPoolSize: 10
-      idleTimeout: 10000
-      poolName: SendLetterHikariCP
-      maxLifetime: 7200000
-      connectionTimeout: 30000
-  # same as ^
-  datasource-v11:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:send-letter-database}:${DB_PORT:5432}/${DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
-    username: ${DB_USER:letterservice}
-    password: ${DB_PASSWORD:}
-    properties:
-      charSet: UTF-8
-    hikari:
-      minimumIdle: 2
-      maximumPoolSize: 10
-      idleTimeout: 10000
-      poolName: SendLetterHikariCP
-      maxLifetime: 7200000
-      connectionTimeout: 30000
+    legacy:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: jdbc:postgresql://${LETTER_TRACKING_DB_HOST:send-letter-database}:${LETTER_TRACKING_DB_PORT:5432}/${LETTER_TRACKING_DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
+      username: ${LETTER_TRACKING_DB_USER_NAME:letterservice}
+      password: ${LETTER_TRACKING_DB_PASSWORD:}
+      properties:
+        charSet: UTF-8
+      hikari:
+        minimumIdle: 2
+        maximumPoolSize: 10
+        idleTimeout: 10000
+        poolName: SendLetterHikariCP
+        maxLifetime: 7200000
+        connectionTimeout: 30000
+    # same as ^
+    v11:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: jdbc:postgresql://${DB_HOST:send-letter-database}:${DB_PORT:5432}/${DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
+      username: ${DB_USER:letterservice}
+      password: ${DB_PASSWORD:}
+      properties:
+        charSet: UTF-8
+      hikari:
+        minimumIdle: 2
+        maximumPoolSize: 10
+        idleTimeout: 10000
+        poolName: SendLetterHikariCP
+        maxLifetime: 7200000
+        connectionTimeout: 30000
   jpa:
     # so spring can auto-detect different sql dialect for each datasource
     database: default

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,35 +22,34 @@ spring:
   application:
     name: Send Letter Service
   datasource:
-    legacy:
-      driver-class-name: org.postgresql.Driver
-      jdbc-url: jdbc:postgresql://${LETTER_TRACKING_DB_HOST:send-letter-database}:${LETTER_TRACKING_DB_PORT:5432}/${LETTER_TRACKING_DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
-      username: ${LETTER_TRACKING_DB_USER_NAME:letterservice}
-      password: ${LETTER_TRACKING_DB_PASSWORD:}
-      properties:
-        charSet: UTF-8
-      hikari:
-        minimumIdle: 2
-        maximumPoolSize: 10
-        idleTimeout: 10000
-        poolName: SendLetterHikariCP
-        maxLifetime: 7200000
-        connectionTimeout: 30000
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${LETTER_TRACKING_DB_HOST:send-letter-database}:${LETTER_TRACKING_DB_PORT:5432}/${LETTER_TRACKING_DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
+    username: ${LETTER_TRACKING_DB_USER_NAME:letterservice}
+    password: ${LETTER_TRACKING_DB_PASSWORD:}
+    properties:
+      charSet: UTF-8
+    hikari:
+      minimumIdle: 2
+      maximumPoolSize: 10
+      idleTimeout: 10000
+      poolName: SendLetterHikariCP
+      maxLifetime: 7200000
+      connectionTimeout: 30000
     # same as ^
-    v11:
-      driver-class-name: org.postgresql.Driver
-      jdbc-url: jdbc:postgresql://${DB_HOST:send-letter-database}:${DB_PORT:5432}/${DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
-      username: ${DB_USER:letterservice}
-      password: ${DB_PASSWORD:}
-      properties:
-        charSet: UTF-8
-      hikari:
-        minimumIdle: 2
-        maximumPoolSize: 10
-        idleTimeout: 10000
-        poolName: SendLetterHikariCP
-        maxLifetime: 7200000
-        connectionTimeout: 30000
+  datasource-v11:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST:send-letter-database}:${DB_PORT:5432}/${DB_NAME:letter_tracking}${LETTER_TRACKING_DB_CONN_OPTIONS:}
+    username: ${DB_USER:letterservice}
+    password: ${DB_PASSWORD:}
+    properties:
+      charSet: UTF-8
+    hikari:
+      minimumIdle: 2
+      maximumPoolSize: 10
+      idleTimeout: 10000
+      poolName: SendLetterHikariCP
+      maxLifetime: 7200000
+      connectionTimeout: 30000
   jpa:
     # so spring can auto-detect different sql dialect for each datasource
     database: default


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Migrate send letter DB to version 11](https://tools.hmcts.net/jira/browse/BPS-1057)

### Change description ###

Follow-up #760. It:

- adds extra set of configs for new db
- assures legacy db config (which is current one) is in use as a primary source

No new ones will be loaded as there are none - job for next PR

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
