### PR TITLE
DTBSP-35: use non standard ftp port to prevent conflict on jenkins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     healthcheck:
       retries: 40
     ports:
-      - "22:22"
+      - "12222:22"
   service-auth-provider-api:
     image: hmctspublic.azurecr.io/rpe/service-auth-provider:latest
     healthcheck:

--- a/src/functionalTest/resources/application.properties
+++ b/src/functionalTest/resources/application.properties
@@ -3,7 +3,7 @@ s2s-name=${TEST_S2S_NAME:send_letter_tests}
 s2s-secret=${TEST_S2S_SECRET:IFAUCQKBIFAUCQKBIFAUCQKBIE======}
 send-letter-service-url=${TEST_URL:http://localhost:8485/}
 ftp-hostname=${TEST_FTP_HOSTNAME:localhost}
-ftp-port=${TEST_FTP_PORT:22}
+ftp-port=${TEST_FTP_PORT:12222}
 ftp-fingerprint=${TEST_FTP_FINGERPRINT:SHA256:H0k+STmmF+iGAH/eMRZyTTnZOn2HfBAgLIC29j7tSXM}
 ftp-target-folder=${FTP_TARGET_FOLDER:incoming}
 ftp-user=${TEST_FTP_USER:sftp}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBP-35


### Change description ###

use non standard ftp port

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
