### PR TITLE
Create new staging dbs v11

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -61,7 +61,7 @@ module "db-v11" {
 
 module "staging-db" {
   source             = "git@github.com:hmcts/cnp-module-postgres?ref=master"
-  product            = "${var.component}-staging-db"
+  product            = "${var.component}-stg-db"
   location           = "${var.location_db}"
   env                = "${var.env}"
   database_name      = "send_letter"


### PR DESCRIPTION
Can't upgrade dbs in-place so creating new staging dbs at v11 - old ones will be deleted.

This only affects the staging dbs - not the main ones!


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
