### PR TITLE
Fix for application_type var in app insights resource

### DIFF
--- a/infrastructure/appinsights.tf
+++ b/infrastructure/appinsights.tf
@@ -8,7 +8,7 @@ resource "azurerm_application_insights" "appinsights" {
     ignore_changes = [
       # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
       # destroys and re-creates this appinsights instance
-      var.application_type,
+      application_type,
     ]
   }
 }


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
