### PR TITLE
Add no fault divorce API to config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -102,6 +102,8 @@ ftp:
       folder: CMC
     - service: send_letter_tests
       folder: BULKPRINT
+    - service: nfdiv_cos
+      folder: DIVORCE
     - service: divorce_frontend
       folder: DIVORCE
     - service: probate_backend


### PR DESCRIPTION
The no fault divorce case orchestration service is a fork of the divorce one. It has a new microservice name so we need to add the mapping. For now it uses the same config/structure as divorce but we may need to change it in the future