### PR TITLE
DTSBPS-964: Added api-key secret

### DIFF
--- a/charts/rpe-send-letter-service/Chart.yaml
+++ b/charts/rpe-send-letter-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: rpe-send-letter-service
 apiVersion: v2
 home: https://github.com/hmcts/send-letter-service
-version: 0.4.5
+version: 0.4.6
 description: HMCTS Send letter service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/rpe-send-letter-service/values.aat.template.yaml
+++ b/charts/rpe-send-letter-service/values.aat.template.yaml
@@ -38,6 +38,8 @@ java:
           alias: DELAYED_STALE_REPORT_RECIPIENTS
         - name: storage-account-connection-string
           alias: STORAGE_ACCOUNT_CONNECTION_STRING
+        - name: actions-api-key
+          alias: ACTIONS_API_KEY
 
   environment:
     FLYWAY_NOOP_STRATEGY: "false"

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -38,6 +38,8 @@ java:
           alias: DELAYED_STALE_REPORT_RECIPIENTS
         - name: storage-account-connection-string
           alias: STORAGE_ACCOUNT_CONNECTION_STRING
+        - name: actions-api-key
+          alias: ACTIONS_API_KEY
 
   environment:
     # db


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-964


### Change description ###
actions-api-key secrets added to rpe-send-letter-prod, rpe-send-letter-aat, rpe-send-letter-demo key vaults.

Currently their values were just copied from the values of reconciliation-report-api-key secret in reform-scan-prod, reform-scan-aat, reform-scan-demo key vaults.

Once process of generation of such api key is clarified - they will be generated.

There will be a PR using these secrets.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
