### PR TITLE
Exclude letters with status 'NotSent' in stale letters (DTSBPS-1004)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepositoryTest.java
@@ -208,24 +208,24 @@ class LetterRepositoryTest {
         // given
         Letter letter1 = SampleData.letterEntity("aService", LocalDateTime.now().minusDays(4));
         letter1.setStatus(Uploaded);
-        Letter savedLetter1 = repository.save(letter1);
 
         Letter letter2 = SampleData.letterEntity("aService", LocalDateTime.now().minusDays(3));
         letter2.setStatus(Created);
-        Letter savedLetter2 = repository.save(letter2);
 
         Letter letter3 = SampleData.letterEntity("aService", LocalDateTime.now().minusDays(4));
         letter3.setStatus(NotSent);
-        Letter savedLetter3 = repository.save(letter3);
 
         Letter letter4 = SampleData.letterEntity("aService", LocalDateTime.now());
         letter3.setStatus(Aborted);
-        Letter savedLetter4 = repository.save(letter4);
-
 
         Letter letter5 = SampleData.letterEntity("aService", LocalDateTime.now());
         letter3.setStatus(Posted);
-        Letter savedLetter5 = repository.save(letter5);
+
+        final Letter savedLetter1 = repository.save(letter1);
+        final Letter savedLetter2 = repository.save(letter2);
+        final Letter savedLetter3 = repository.save(letter3);
+        final Letter savedLetter4 = repository.save(letter4);
+        final Letter savedLetter5 = repository.save(letter5);
 
         // when
         List<BasicLetterInfo> staleLetters = repository.findStaleLetters(LocalDateTime.now().minusDays(1));

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -26,7 +26,7 @@ public interface LetterRepository extends JpaRepository<Letter, UUID> {
 
     @Query("select new uk.gov.hmcts.reform.sendletter.entity.BasicLetterInfo(l.id, l.checksum, l.service, l.status, l.type, l.encryptionKeyFingerprint, l.createdAt, l.sentToPrintAt, l.printedAt)"
         + " from Letter l "
-        + " where l.status not in ('Posted', 'Aborted')"
+        + " where l.status not in ('Posted', 'Aborted', 'NotSent')"
         + " and l.createdAt < :createdBefore"
         + " and l.type <> '" + UploadLettersTask.SMOKE_TEST_LETTER_TYPE + "'"
         + " order by l.createdAt asc")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-1004

### Change description ###
State letters endpoint should not return letters with status 'NotSent'.
Fix the repository method ti exclude status 'NotSent'


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
