### PR TITLE
Re-process letters failed to upload to FTP server (DTSBPS-1024)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepositoryTest.java
@@ -102,7 +102,7 @@ class LetterRepositoryTest {
         Letter savedLetter = repository.save(letter);
 
         // when
-        int updateCount = repository.markStaleLetterAsCreated(savedLetter.getId());
+        int updateCount = repository.markLetterAsCreated(savedLetter.getId());
 
         // then
         assertThat(updateCount).isEqualTo(1);
@@ -139,7 +139,7 @@ class LetterRepositoryTest {
         repository.save(letter);
 
         // when
-        int updateCount = repository.markStaleLetterAsCreated(UUID.randomUUID());
+        int updateCount = repository.markLetterAsCreated(UUID.randomUUID());
 
         // then
         assertThat(updateCount).isEqualTo(0);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/ResponseExceptionHandler.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.sendletter.exception.LetterSaveException;
 import uk.gov.hmcts.reform.sendletter.exception.ServiceNotConfiguredException;
 import uk.gov.hmcts.reform.sendletter.exception.UnableToAbortLetterException;
 import uk.gov.hmcts.reform.sendletter.exception.UnableToGenerateSasTokenException;
+import uk.gov.hmcts.reform.sendletter.exception.UnableToReprocessLetterException;
 import uk.gov.hmcts.reform.sendletter.exception.UnauthenticatedException;
 import uk.gov.hmcts.reform.sendletter.model.out.errors.FieldError;
 import uk.gov.hmcts.reform.sendletter.model.out.errors.ModelValidationError;
@@ -136,8 +137,14 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(UnableToAbortLetterException.class)
-    protected ResponseEntity<Void> handleUnsupportedLetterStatusException(UnableToAbortLetterException exc) {
+    protected ResponseEntity<String> handleUnableToAbortLetterException(UnableToAbortLetterException exc) {
         log.warn(exc.getMessage(), exc);
-        return status(BAD_REQUEST).build();
+        return status(BAD_REQUEST).body("Status is not supported to abort the letter");
+    }
+
+    @ExceptionHandler(UnableToReprocessLetterException.class)
+    protected ResponseEntity<String> handleUnableToReprocessLetterException(UnableToReprocessLetterException exc) {
+        log.warn(exc.getMessage(), exc);
+        return status(BAD_REQUEST).body("Status is not supported to re-process the letter");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/LetterRepository.java
@@ -93,7 +93,7 @@ public interface LetterRepository extends JpaRepository<Letter, UUID> {
         + " SET l.status = 'Created'"
         + " WHERE l.id = :id AND l.status = 'Uploaded'"
     )
-    int markStaleLetterAsCreated(@Param("id") UUID id);
+    int markLetterAsCreated(@Param("id") UUID id);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Letter l"

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnableToReprocessLetterException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/exception/UnableToReprocessLetterException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.sendletter.exception;
+
+public class UnableToReprocessLetterException extends RuntimeException {
+
+    public UnableToReprocessLetterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterActionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterActionService.java
@@ -11,13 +11,18 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterEventRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.exception.UnableToAbortLetterException;
+import uk.gov.hmcts.reform.sendletter.exception.UnableToReprocessLetterException;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static uk.gov.hmcts.reform.sendletter.entity.EventType.MANUALLY_MARKED_AS_ABORTED;
+import static uk.gov.hmcts.reform.sendletter.entity.EventType.MANUALLY_MARKED_AS_CREATED;
+import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.FailedToUpload;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Posted;
+import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Uploaded;
 
 @Service
 public class LetterActionService {
@@ -25,10 +30,14 @@ public class LetterActionService {
 
     private final LetterRepository letterRepository;
     private final LetterEventRepository letterEventRepository;
+    private final StaleLetterService staleLetterService;
 
-    public LetterActionService(LetterRepository letterRepository, LetterEventRepository letterEventRepository) {
+    public LetterActionService(LetterRepository letterRepository,
+                               LetterEventRepository letterEventRepository,
+                               StaleLetterService staleLetterService) {
         this.letterRepository = letterRepository;
         this.letterEventRepository = letterEventRepository;
+        this.staleLetterService = staleLetterService;
     }
 
     @Transactional
@@ -53,6 +62,36 @@ public class LetterActionService {
             "Letter marked manually as Aborted to stop processing");
 
         return letterRepository.markLetterAsAborted(id);
+    }
+
+    @Transactional
+    public int markLetterAsCreated(UUID id) {
+        log.info("Marking the letter id {} as Created to re-upload to SFTP server", id);
+
+        Optional<Letter> letterOpt = letterRepository.findById(id);
+
+        if (letterOpt.isEmpty()) {
+            throw new LetterNotFoundException(id);
+        }
+
+        Letter letter = letterOpt.get();
+        checkLetterStatus(letter);
+
+        if (letter.getStatus() == FailedToUpload) {
+            createLetterEvent(letter, MANUALLY_MARKED_AS_CREATED, "Letter marked manually as Created to re-process");
+            return letterRepository.markLetterAsCreated(letter.getId());
+        } else {
+            return staleLetterService.markStaleLetterAsCreated(id);
+        }
+    }
+
+    private void checkLetterStatus(Letter letter) {
+        if (!List.of(FailedToUpload, Uploaded).contains(letter.getStatus())) {
+            throw new UnableToReprocessLetterException(
+                "Letter with ID '" + letter.getId() + "', status '"
+                    + letter.getStatus() + "' can not be re-processed");
+        }
+
     }
 
     private void createLetterEvent(Letter letter, EventType type, String notes) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterService.java
@@ -115,7 +115,7 @@ public class StaleLetterService {
                 "Letter marked manually as created for reprocessing"
         );
 
-        return letterRepository.markStaleLetterAsCreated(id);
+        return letterRepository.markLetterAsCreated(id);
     }
 
     private void prepareChangingLetterStatus(UUID id, EventType manuallyMarkedStatus, String notes) {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterActionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/LetterActionServiceTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.sendletter.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -10,8 +12,10 @@ import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterEvent;
 import uk.gov.hmcts.reform.sendletter.entity.LetterEventRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
+import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.exception.UnableToAbortLetterException;
+import uk.gov.hmcts.reform.sendletter.exception.UnableToReprocessLetterException;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -25,6 +29,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.sendletter.entity.EventType.MANUALLY_MARKED_AS_ABORTED;
+import static uk.gov.hmcts.reform.sendletter.entity.EventType.MANUALLY_MARKED_AS_CREATED;
+import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.FailedToUpload;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Posted;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Uploaded;
 
@@ -37,11 +43,14 @@ class LetterActionServiceTest {
     @Mock
     private LetterEventRepository letterEventRepository;
 
+    @Mock
+    private StaleLetterService staleLetterService;
+
     private LetterActionService letterActionService;
 
     @BeforeEach
     void setUp() {
-        letterActionService = new LetterActionService(letterRepository, letterEventRepository);
+        letterActionService = new LetterActionService(letterRepository, letterEventRepository, staleLetterService);
     }
 
     @Test
@@ -128,6 +137,129 @@ class LetterActionServiceTest {
 
         verifyNoMoreInteractions(letterRepository);
         verifyNoInteractions(letterEventRepository);
+    }
+
+    @Test
+    void should_update_letter_status_created_when_record_present_and_status_upload_failed() {
+        // given
+        UUID letterId = UUID.randomUUID();
+
+        Letter letter = new Letter(
+            letterId,
+            letterId.toString(),
+            "cmc",
+            null,
+            "type",
+            null,
+            false,
+            null,
+            LocalDateTime.now(),
+            null
+        );
+        letter.setStatus(FailedToUpload);
+
+        reset(letterRepository);
+        given(letterRepository.findById(letterId)).willReturn(Optional.of(letter));
+        given(letterRepository.markLetterAsCreated(letterId)).willReturn(1);
+
+        // when
+        int result = letterActionService.markLetterAsCreated(letterId);
+
+        // then
+        assertThat(result).isEqualTo(1);
+
+        ArgumentCaptor<LetterEvent> letterEventArgumentCaptor = ArgumentCaptor.forClass(LetterEvent.class);
+        verify(letterEventRepository).save(letterEventArgumentCaptor.capture());
+        assertThat(letterEventArgumentCaptor.getValue().getLetter()).isEqualTo(letter);
+        assertThat(letterEventArgumentCaptor.getValue().getType()).isEqualTo(MANUALLY_MARKED_AS_CREATED);
+        assertThat(letterEventArgumentCaptor.getValue().getNotes())
+            .isEqualTo("Letter marked manually as Created to re-process");
+
+        verify(letterRepository).markLetterAsCreated(letterId);
+        verifyNoMoreInteractions(staleLetterService, letterRepository, letterEventRepository);
+    }
+
+    @Test
+    void should_update_letter_status_created_when_record_present_and_status_is_created() {
+        // given
+        UUID letterId = UUID.randomUUID();
+
+        Letter letter = new Letter(
+            letterId,
+            letterId.toString(),
+            "cmc",
+            null,
+            "type",
+            null,
+            false,
+            null,
+            LocalDateTime.now(),
+            null
+        );
+        letter.setStatus(Uploaded);
+
+        reset(letterRepository);
+        given(letterRepository.findById(letterId)).willReturn(Optional.of(letter));
+        given(staleLetterService.markStaleLetterAsCreated(letterId)).willReturn(1);
+
+        // when
+        int result = letterActionService.markLetterAsCreated(letterId);
+
+        // then
+        assertThat(result).isEqualTo(1);
+
+        verify(staleLetterService).markStaleLetterAsCreated(letterId);
+        verifyNoMoreInteractions(letterRepository, letterEventRepository);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = LetterStatus.class,
+        names = {"Uploaded", "FailedToUpload"},
+        mode = EnumSource.Mode.EXCLUDE)
+    void should_throw_exception_when_letter_status_is_not_created_or_upload_failed(LetterStatus status) {
+        // given
+        UUID letterId = UUID.randomUUID();
+        Letter letter = new Letter(
+            letterId,
+            letterId.toString(),
+            "cmc",
+            null,
+            "type",
+            null,
+            false,
+            null,
+            LocalDateTime.now(),
+            null
+        );
+        letter.setStatus(status);
+
+        reset(letterRepository);
+        given(letterRepository.findById(letterId)).willReturn(Optional.of(letter));
+
+        // when
+        // then
+        assertThatThrownBy(() -> letterActionService.markLetterAsCreated(letterId))
+            .isInstanceOf(UnableToReprocessLetterException.class);
+
+        verifyNoMoreInteractions(letterRepository);
+        verifyNoInteractions(staleLetterService, letterEventRepository);
+    }
+
+    @Test
+    void reprocess_letter_should_throw_exception_when_letter_not_present() {
+        // given
+        UUID letterId = UUID.randomUUID();
+        reset(letterRepository);
+        given(letterRepository.findById(letterId)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> letterActionService.markLetterAsCreated(letterId))
+            .isInstanceOf(LetterNotFoundException.class);
+
+        verifyNoMoreInteractions(letterRepository);
+        verifyNoInteractions(staleLetterService, letterEventRepository);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/StaleLetterServiceTest.java
@@ -417,7 +417,7 @@ class StaleLetterServiceTest {
 
         reset(letterRepository);
         given(letterRepository.findById(letterId)).willReturn(Optional.of(letter));
-        given(letterRepository.markStaleLetterAsCreated(letterId)).willReturn(1);
+        given(letterRepository.markLetterAsCreated(letterId)).willReturn(1);
 
         String ftpDowntimeStartTime = "16:00";
 
@@ -437,7 +437,7 @@ class StaleLetterServiceTest {
         assertThat(letterEventArgumentCaptor.getValue().getNotes())
             .isEqualTo("Letter marked manually as created for reprocessing");
 
-        verify(letterRepository).markStaleLetterAsCreated(letterId);
+        verify(letterRepository).markLetterAsCreated(letterId);
         verifyNoMoreInteractions(letterRepository, letterEventRepository);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-1024

### Change description ###
Letters failed to upload to the FTP server are stuck in `FailedToUpload` status.
Add service method to update the letter status as `Created` to try re-uploading the letter to SFTP server.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
