### PR TITLE
Configure for FTP uploaded files summary daily report (DTSBPS-1023)

### DIFF
--- a/charts/rpe-send-letter-service/Chart.yaml
+++ b/charts/rpe-send-letter-service/Chart.yaml
@@ -1,7 +1,7 @@
 name: rpe-send-letter-service
 apiVersion: v2
 home: https://github.com/hmcts/send-letter-service
-version: 0.4.7
+version: 0.4.8
 description: HMCTS Send letter service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/rpe-send-letter-service/values.yaml
+++ b/charts/rpe-send-letter-service/values.yaml
@@ -75,6 +75,7 @@ java:
 
     #reports. depends on smtp - For prod overwrite
     UPLOAD_SUMMARY_REPORT_ENABLED: "false"
+    FTP_UPLOADED_LETTERS_SUMMARY_REPORT_ENABLED: "false"
 
   # Don't modify below here
   image: 'hmctspublic.azurecr.io/rpe/send-letter-service:latest'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportDisabledByComponentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportDisabledByComponentTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+    "spring.mail.host=false"
+})
+class DailyFtpLetterUploadSummaryReportDisabledByComponentTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void should_not_have_report_sender_in_context() {
+        assertThat(context.getBeanNamesForType(DailyFtpLetterUploadSummaryReport.class)).isEmpty();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportDisabledTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+    "reports.ftp-uploaded-letters-summary.enabled=false"
+})
+class DailyFtpLetterUploadSummaryReportDisabledTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void should_not_have_report_sender_in_context() {
+        assertThat(context.getBeanNamesForType(DailyFtpLetterUploadSummaryReport.class)).isEmpty();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportTest.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.sendletter.tasks.reports;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import uk.gov.hmcts.reform.sendletter.services.FtpFileSummaryService;
+
+import java.io.File;
+import javax.mail.internet.MimeMessage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class DailyFtpLetterUploadSummaryReportTest {
+
+    @Mock
+    private FtpFileSummaryService ftpFileSummaryService;
+
+    @Value("${reports.upload-summary.recipients}")
+    private String[] recipients;
+
+    @Autowired
+    private EmailSender emailSender;
+
+    @SpyBean
+    private JavaMailSender mailSender;
+
+    @Autowired
+    private DailyFtpLetterUploadSummaryReport report;
+
+    @Test
+    void should_attempt_to_send_report_when_recipients_list_is_present() throws Exception {
+        when(ftpFileSummaryService.getFtpFileUploadSummaryFiles())
+            .thenReturn(ImmutableMap.of("a", new File("a.zip")));
+        report = new DailyFtpLetterUploadSummaryReport(ftpFileSummaryService, emailSender, recipients);
+
+        report.send();
+
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportTest.java
@@ -23,7 +23,7 @@ class DailyFtpLetterUploadSummaryReportTest {
     @Mock
     private FtpFileSummaryService ftpFileSummaryService;
 
-    @Value("${reports.upload-summary.recipients}")
+    @Value("${reports.ftp-uploaded-letters-summary.recipients}")
     private String[] recipients;
 
     @Autowired

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -34,6 +34,8 @@ spring.mail.test-connection=false
 
 reports.upload-summary.enabled=true
 reports.upload-summary.recipients=integration@test
+reports.ftp-uploaded-letters-summary.enabled=true
+reports.ftp-uploaded-letters-summary.recipients=integration@test
 
 azure.application-insights.instrumentation-key=integration-test
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReport.java
@@ -37,7 +37,7 @@ public class DailyFtpLetterUploadSummaryReport {
     public DailyFtpLetterUploadSummaryReport(
         FtpFileSummaryService ftpFileSummaryService,
         EmailSender emailSender,
-        @Value("${reports.upload-summary.recipients}") String[] recipients
+        @Value("${reports.ftp-uploaded-letters-summary.recipients}") String[] recipients
     ) {
         this.ftpFileSummaryService = ftpFileSummaryService;
         this.emailSender = emailSender;

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReport.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.sendletter.tasks.reports;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.services.FtpFileSummaryService;
 
@@ -14,10 +17,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
+
 @Component
 @ConditionalOnBean(EmailSender.class)
-public class DailyFtpFileUploadSummaryReport {
-    private static final Logger log = LoggerFactory.getLogger(DailyFtpFileUploadSummaryReport.class);
+@ConditionalOnProperty(prefix = "reports.ftp-uploaded-letters-summary", name = "enabled")
+public class DailyFtpLetterUploadSummaryReport {
+    private static final Logger log = LoggerFactory.getLogger(DailyFtpLetterUploadSummaryReport.class);
 
     private final FtpFileSummaryService ftpFileSummaryService;
     private final EmailSender emailSender;
@@ -28,15 +34,18 @@ public class DailyFtpFileUploadSummaryReport {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
 
-    public DailyFtpFileUploadSummaryReport(FtpFileSummaryService ftpFileSummaryService,
-                                           EmailSender emailSender,
-                                           @Value("${reports.upload-summary.recipients}") String[] recipients
+    public DailyFtpLetterUploadSummaryReport(
+        FtpFileSummaryService ftpFileSummaryService,
+        EmailSender emailSender,
+        @Value("${reports.upload-summary.recipients}") String[] recipients
     ) {
         this.ftpFileSummaryService = ftpFileSummaryService;
         this.emailSender = emailSender;
         this.recipients = recipients;
     }
 
+    @SchedulerLock(name = "daily-ftp-uploaded-letters-summary", lockAtLeastFor = "PT5S")
+    @Scheduled(cron = "${reports.ftp-uploaded-letters-summary.cron}", zone = EUROPE_LONDON)
     public void send() {
         if (recipients == null || recipients.length == 0) {
             log.error("No recipients configured to send daily FTP letters report");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,6 +64,10 @@ reports:
     cron: ${UPLOAD_SUMMARY_REPORT_CRON:0 0 19 * * *}
     enabled: ${UPLOAD_SUMMARY_REPORT_ENABLED:false}
     recipients: ${UPLOAD_SUMMARY_REPORT_RECIPIENTS:}
+  ftp-uploaded-letters-summary:
+    cron: ${FTP_UPLOADED_LETTERS_SUMMARY_REPORT_CRON:45 59 15 * * *}
+    enabled: ${FTP_UPLOADED_LETTERS_SUMMARY_REPORT_ENABLED:false}
+    recipients: ${UPLOAD_SUMMARY_REPORT_RECIPIENTS:}
   service-config:
     - service: cmc_claim_store
       display-name: CMC
@@ -93,7 +97,7 @@ ftp:
   target-folder: ${FTP_TARGET_FOLDER}
   smoke-test-target-folder: ${FTP_SMOKE_TEST_TARGET_FOLDER:SMOKE_TEST}
   reports-folder: ${FTP_REPORTS_FOLDER}
-  reports-cron: ${FTP_REPORTS_CRON:0 30 0 * * *}
+  reports-cron: ${FTP_REPORTS_CRON:"30 59 15 * * ?"}
   fingerprint: ${FTP_FINGERPRINT}
   username: ${FTP_USER}
   privateKey: ${FTP_PRIVATE_KEY}

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/reports/DailyFtpLetterUploadSummaryReportTest.java
@@ -20,11 +20,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.sendletter.tasks.reports.DailyFtpFileUploadSummaryReport.ATTACHMENT_NAME_FORMAT;
-import static uk.gov.hmcts.reform.sendletter.tasks.reports.DailyFtpFileUploadSummaryReport.EMAIL_SUBJECT;
+import static uk.gov.hmcts.reform.sendletter.tasks.reports.DailyFtpLetterUploadSummaryReport.ATTACHMENT_NAME_FORMAT;
+import static uk.gov.hmcts.reform.sendletter.tasks.reports.DailyFtpLetterUploadSummaryReport.EMAIL_SUBJECT;
 
 @ExtendWith(MockitoExtension.class)
-class DailyFtpFileUploadSummaryReportTest {
+class DailyFtpLetterUploadSummaryReportTest {
 
     @Mock
     private FtpFileSummaryService ftpFileSummaryService;
@@ -41,7 +41,7 @@ class DailyFtpFileUploadSummaryReportTest {
     @Captor
     ArgumentCaptor<String[]> recipientsCaptor;
 
-    private DailyFtpFileUploadSummaryReport dailyFtpFileUploadSummaryReport;
+    private DailyFtpLetterUploadSummaryReport dailyFtpLetterUploadSummaryReport;
 
     String[] recipients = null;
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -50,7 +50,7 @@ class DailyFtpFileUploadSummaryReportTest {
     void should_send_email_for_all_recipients() {
         // given
         recipients = new String[]{"test1@dummy.com", "test2@dummy.com"};
-        dailyFtpFileUploadSummaryReport = new DailyFtpFileUploadSummaryReport(
+        dailyFtpLetterUploadSummaryReport = new DailyFtpLetterUploadSummaryReport(
             ftpFileSummaryService, emailSender, recipients);
 
         File serviceFile1 = new File("service1-file");
@@ -59,7 +59,7 @@ class DailyFtpFileUploadSummaryReportTest {
             .willReturn(ImmutableMap.of("service1", serviceFile1, "service2", serviceFile2));
 
         // when
-        dailyFtpFileUploadSummaryReport.send();
+        dailyFtpLetterUploadSummaryReport.send();
 
         // then
         verify(emailSender).send(emailSubjectCaptor.capture(), recipientsCaptor.capture(),
@@ -77,11 +77,11 @@ class DailyFtpFileUploadSummaryReportTest {
     void should_not_send_a_report_when_no_recipients_are_configured() {
         // given
         recipients = new String[]{};
-        dailyFtpFileUploadSummaryReport = new DailyFtpFileUploadSummaryReport(
+        dailyFtpLetterUploadSummaryReport = new DailyFtpLetterUploadSummaryReport(
             ftpFileSummaryService, emailSender, recipients);
 
         // when
-        dailyFtpFileUploadSummaryReport.send();
+        dailyFtpLetterUploadSummaryReport.send();
 
         // then
         verify(ftpFileSummaryService, never()).getFtpFileUploadSummaryFiles();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-1023

### Change description ###
Add config to email daily report for FTP uploaded files.
This report is disabled by default. It'll be enabled in Flux config after testing in lower environments.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
