### PR TITLE
Fix scala-library vulnerability (DTSBPS-1105)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,11 @@ dependencyManagement {
       entry 'guava'
     }
 
+    // CVE-2022-36944
+    dependencySet(group: 'org.scala-lang', version: '2.13.9') {
+      entry 'scala-library'
+    }
+
     // avoid CVE-2021-29425
     dependencySet(group: 'commons-io', version: '2.11.0') {
       entry 'commons-io'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,4 @@
         <cve>CVE-2022-40149</cve>
         <cve>CVE-2022-40150</cve>
     </suppress>
-    <suppress until="2022-12-30">
-        <cve>CVE-2022-36944</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-1105


### Change description ###
Use scala-library version '2.13.9' to fix CVE-2022-36944


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
