### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ application-default.yaml
 /bin/setup-env.sh
 /bin/substitutions.json
 /bin/create-env-file.sh
+/bin/*

--- a/infrastructure/appinsights.tf
+++ b/infrastructure/appinsights.tf
@@ -1,21 +1,22 @@
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.send-letter-key-vault.key_vault_id
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.component}-appinsights-${var.env}"
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env                 = var.env
+  product             = var.product
+  name                = "${var.product}-${var.component}-appinsights"
   location            = var.appinsights_location
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  tags                = var.common_tags
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+  common_tags = var.common_tags
+}
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }

--- a/infrastructure/exception-alert.tf
+++ b/infrastructure/exception-alert.tf
@@ -1,7 +1,7 @@
 module "send-letter-service-exception-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Send_Letter_Service_exception_-_BSP"

--- a/infrastructure/is_down_alert.tf
+++ b/infrastructure/is_down_alert.tf
@@ -1,7 +1,7 @@
 module "send-letter-up-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Send_Letter_is_DOWN_-_BSP"

--- a/infrastructure/liveness-alert.tf
+++ b/infrastructure/liveness-alert.tf
@@ -1,7 +1,7 @@
 module "send-letter-service-liveness-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Send_Letter_Service_liveness_-_BSP"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -104,7 +104,7 @@ resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
 resource "azurerm_key_vault_secret" "APP-INSTRUMENTATION-KEY" {
   key_vault_id = module.send-letter-key-vault.key_vault_id
   name         = "app-insights-instrumentation-key"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
 }
 
 # endregion

--- a/infrastructure/pending-letter-alert.tf
+++ b/infrastructure/pending-letter-alert.tf
@@ -1,7 +1,7 @@
 module "send-letter-service-pending-letter-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Send_Letter_Service_Pending_Letter_-_BSP"

--- a/infrastructure/stale-letter-alert.tf
+++ b/infrastructure/stale-letter-alert.tf
@@ -1,7 +1,7 @@
 module "send-letter-service-stale-letter-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Send_Letter_Service_Stale_Letter_-_BSP"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.