### PR TITLE
FACT-1593 Adding international postage support (w/ feature flagging) [DO NOT MERGE]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,7 @@ implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-t
   testImplementation group: 'org.apache.pdfbox', name: 'preflight', version: '2.0.30', withoutJunit4
   testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.1', withoutJunit4
   testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.3.0', classifier: 'all'
+  testImplementation group: 'io.github.hakky54', name: 'logcaptor', version: '2.3.1'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -111,6 +111,7 @@ class UploadLettersTaskTest {
             availabilityChecker,
             letterEventService,
             serviceFolderMapping,
+            launchDarklyClient,
             0
         );
 
@@ -148,6 +149,7 @@ class UploadLettersTaskTest {
             availabilityChecker,
             letterEventService,
             serviceFolderMapping,
+            launchDarklyClient,
             0
         );
 
@@ -184,6 +186,7 @@ class UploadLettersTaskTest {
             availabilityChecker,
             letterEventService,
             serviceFolderMapping,
+            launchDarklyClient,
             0
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/launchdarkly/Flags.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/launchdarkly/Flags.java
@@ -6,4 +6,5 @@ public final class Flags {
     }
 
     public static final String SEND_LETTER_SERVICE_TEST = "send-letter-service-test";
+    public static final String FACT_1593_INTERNATIONAL_POST_FLAG = "FACT-1593-international-post-flag";
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
+import uk.gov.hmcts.reform.sendletter.launchdarkly.LaunchDarklyClient;
 import uk.gov.hmcts.reform.sendletter.services.LetterEventService;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
@@ -25,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static java.time.LocalDateTime.now;
+import static uk.gov.hmcts.reform.sendletter.launchdarkly.Flags.FACT_1593_INTERNATIONAL_POST_FLAG;
 import static uk.gov.hmcts.reform.sendletter.util.TimeZones.EUROPE_LONDON;
 
 @Component
@@ -42,21 +44,24 @@ public class UploadLettersTask {
     private final IFtpAvailabilityChecker availabilityChecker;
     private final LetterEventService letterEventService;
     private final ServiceFolderMapping serviceFolderMapping;
+    private final LaunchDarklyClient launchDarklyClient;
     private final int dbPollDelay;
 
     public UploadLettersTask(
-            LetterRepository repo,
-            FtpClient ftp,
-            IFtpAvailabilityChecker availabilityChecker,
-            LetterEventService letterEventService,
-            ServiceFolderMapping serviceFolderMapping,
-            @Value("${tasks.upload-letters.db-poll-delay}") int dbPollDelay
+        LetterRepository repo,
+        FtpClient ftp,
+        IFtpAvailabilityChecker availabilityChecker,
+        LetterEventService letterEventService,
+        ServiceFolderMapping serviceFolderMapping,
+        LaunchDarklyClient launchDarklyClient,
+        @Value("${tasks.upload-letters.db-poll-delay}") int dbPollDelay
     ) {
         this.repo = repo;
         this.ftp = ftp;
         this.availabilityChecker = availabilityChecker;
         this.letterEventService = letterEventService;
         this.serviceFolderMapping = serviceFolderMapping;
+        this.launchDarklyClient = launchDarklyClient;
         this.dbPollDelay = dbPollDelay;
     }
 
@@ -114,10 +119,12 @@ public class UploadLettersTask {
 
         if (serviceFolder.isPresent()) {
             String grabbedServiceFolder = serviceFolder.get();
-            if (letter.getAdditionalData() != null
-                && letter.getAdditionalData().has("isInternational")
-                && letter.getAdditionalData().get("isInternational").asBoolean()) {
-                grabbedServiceFolder = serviceFolder.get() + INTERNATIONAL_FOLDER;
+            if (launchDarklyClient.isFeatureEnabled(FACT_1593_INTERNATIONAL_POST_FLAG)) {
+                if (letter.getAdditionalData() != null
+                    && letter.getAdditionalData().has("isInternational")
+                    && letter.getAdditionalData().get("isInternational").asBoolean()) {
+                    grabbedServiceFolder = serviceFolder.get() + INTERNATIONAL_FOLDER;
+                }
             }
             uploadLetter(letter, grabbedServiceFolder, sftpClient);
             letter.setStatus(LetterStatus.Uploaded);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -135,7 +135,7 @@ public class UploadLettersTask {
         }
     }
 
-    private void uploadLetter(Letter letter, String folder, SFTPClient sftpClient) {
+    protected void uploadLetter(Letter letter, String folder, SFTPClient sftpClient) {
         FileToSend file = new FileToSend(
             FileNameHelper.generateName(letter),
             letter.getFileContent(),

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -114,11 +114,12 @@ public class UploadLettersTask {
 
         if (serviceFolder.isPresent()) {
             String grabbedServiceFolder = serviceFolder.get();
-            if(letter.getAdditionalData() != null && letter.getAdditionalData().has("isInternational") &&
-                letter.getAdditionalData().get("isInternational").asBoolean()){
+            if (letter.getAdditionalData() != null
+                && letter.getAdditionalData().has("isInternational")
+                && letter.getAdditionalData().get("isInternational").asBoolean()) {
                 grabbedServiceFolder = serviceFolder.get() + INTERNATIONAL_FOLDER;
             }
-            uploadLetter(letter, grabbedServiceFolder , sftpClient);
+            uploadLetter(letter, grabbedServiceFolder, sftpClient);
             letter.setStatus(LetterStatus.Uploaded);
             letter.setSentToPrintAt(now());
             repo.saveAndFlush(letter);
@@ -145,11 +146,15 @@ public class UploadLettersTask {
         ftp.upload(file, folder, sftpClient);
 
         logger.info(
-            "Uploaded letter id: {}, checksum: {}, file name: {}, additional data: {}",
-            letter.getId(),
-            letter.getChecksum(),
-            file.filename,
-            letter.getAdditionalData()
+            String.format(
+                "Uploaded letter id: %s, checksum: %s, file name: %s, folder: %s, additional data: %s",
+                letter.getId(),
+                letter.getChecksum(),
+                file.filename,
+                folder,
+                letter.getAdditionalData()
+
+            )
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -143,7 +143,7 @@ public class UploadLettersTask {
         }
     }
 
-    protected void uploadLetter(Letter letter, String folder, SFTPClient sftpClient) {
+    private void uploadLetter(Letter letter, String folder, SFTPClient sftpClient) {
         FileToSend file = new FileToSend(
             FileNameHelper.generateName(letter),
             letter.getFileContent(),

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.exception.FtpException;
+import uk.gov.hmcts.reform.sendletter.launchdarkly.LaunchDarklyClient;
 import uk.gov.hmcts.reform.sendletter.services.LetterEventService;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FileToSend;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
@@ -48,6 +49,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Created;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Skipped;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Uploaded;
+import static uk.gov.hmcts.reform.sendletter.launchdarkly.Flags.FACT_1593_INTERNATIONAL_POST_FLAG;
 import static uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask.SMOKE_TEST_LETTER_TYPE;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,6 +72,9 @@ class UploadLettersTaskTest {
 
     @Mock
     private ServiceFolderMapping serviceFolderMapping;
+
+    @Mock
+    private LaunchDarklyClient launchDarklyClient;
 
     private final ArgumentCaptor<FileToSend> captureFileToSend = ArgumentCaptor.forClass(FileToSend.class);
 
@@ -97,6 +102,8 @@ class UploadLettersTaskTest {
     void should_handle_smoke_test_letters() {
         // given
         given(serviceFolderMapping.getFolderFor(any())).willReturn(Optional.of("some_folder"));
+
+        given(launchDarklyClient.isFeatureEnabled(FACT_1593_INTERNATIONAL_POST_FLAG)).willReturn(true);
 
         given(repo.countByStatus(Created)).willReturn(2);
 
@@ -138,6 +145,8 @@ class UploadLettersTaskTest {
     void should_handle_smoke_test_international_letters() {
         // given
         given(serviceFolderMapping.getFolderFor(any())).willReturn(Optional.of("some_folder/international"));
+
+        given(launchDarklyClient.isFeatureEnabled(FACT_1593_INTERNATIONAL_POST_FLAG)).willReturn(true);
 
         given(repo.countByStatus(Created)).willReturn(2);
 
@@ -366,6 +375,7 @@ class UploadLettersTaskTest {
             availabilityChecker,
             letterEventService,
             serviceFolderMapping,
+            launchDarklyClient,
             0
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -33,15 +33,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Created;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Skipped;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Uploaded;
@@ -111,11 +104,11 @@ class UploadLettersTaskTest {
             .mapToInt(function -> function.apply(sftpClient))
             .sum();
 
-//        UploadLettersTask upTask = spy(UploadLettersTask.class);
-//        ArgumentArgumentCaptorCaptor<String> capturedServiceFolder = ArgumentCaptor.forClass(String.class);
-//        verify(upTask).uploadLetter(any(),capturedServiceFolder.capture(),any());
-//        String serviceFolder = capturedServiceFolder.getValue();
-//        assertThat(serviceFolder).isEqualTo(null); //null since additionalData is null for this letter
+        UploadLettersTask upTask = spy(UploadLettersTask.class);
+        ArgumentCaptor<String> capturedServiceFolder = ArgumentCaptor.forClass(String.class);
+        verify(upTask).uploadLetter(any(),capturedServiceFolder.capture(),any());
+        String serviceFolder = capturedServiceFolder.getValue();
+        assertThat(serviceFolder).isEqualTo(null); //null since additionalData is null for this letter
 
         // then
         assertThat(uploadAttempts).isEqualTo(2);

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Created;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Skipped;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Uploaded;
@@ -109,6 +110,12 @@ class UploadLettersTaskTest {
             .stream()
             .mapToInt(function -> function.apply(sftpClient))
             .sum();
+
+//        UploadLettersTask upTask = spy(UploadLettersTask.class);
+//        ArgumentArgumentCaptorCaptor<String> capturedServiceFolder = ArgumentCaptor.forClass(String.class);
+//        verify(upTask).uploadLetter(any(),capturedServiceFolder.capture(),any());
+//        String serviceFolder = capturedServiceFolder.getValue();
+//        assertThat(serviceFolder).isEqualTo(null); //null since additionalData is null for this letter
 
         // then
         assertThat(uploadAttempts).isEqualTo(2);
@@ -280,6 +287,10 @@ class UploadLettersTaskTest {
         return letter("cmc", type, copies);
     }
 
+    private Letter internationalLetterOfType(String type,  Map<String, Integer> copies) {
+        return internationalLetter("cmc", type, copies);
+    }
+
     private Letter letterForService(String serviceName,  Map<String, Integer> copies) {
         return letter(serviceName, "type", copies);
     }
@@ -290,6 +301,21 @@ class UploadLettersTaskTest {
             "msgId",
             service,
             null,
+            type,
+            "hello".getBytes(),
+            true,
+            "9c61b7da4e6c94416be51136122ed01acea9884f",
+            now(),
+            objectMapper.valueToTree(copies)
+        );
+    }
+
+    private Letter internationalLetter(String service, String type, Map<String, Integer> copies) {
+        return new Letter(
+            UUID.randomUUID(),
+            "msgId",
+            service,
+            new ObjectMapper().createObjectNode().put("isInternational",true),
             type,
             "hello".getBytes(),
             true,

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -108,7 +108,7 @@ class UploadLettersTaskTest {
         ArgumentCaptor<String> capturedServiceFolder = ArgumentCaptor.forClass(String.class);
         verify(upTask).uploadLetter(any(),capturedServiceFolder.capture(),any());
         String serviceFolder = capturedServiceFolder.getValue();
-        assertThat(serviceFolder).isEqualTo(null); //null since additionalData is null for this letter
+        assertThat(serviceFolder).isEqualTo("some_folder"); //null since additionalData is null for this letter
 
         // then
         assertThat(uploadAttempts).isEqualTo(2);


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1593


### Change description ###
when a feild for 'isInternational' boolean exists with a true value then the target folder changes to '/<target_folder>/international' from '/<target_folder>'
this is feature flagged under 'FACT-1593-international-post-flag'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
