### PR TITLE
FACT-1593 'international' folder is meant to be 'International'

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTask.java
@@ -37,7 +37,7 @@ public class UploadLettersTask {
     public static final int BATCH_SIZE = 10;
     public static final String SMOKE_TEST_LETTER_TYPE = "smoke_test";
     private static final String TASK_NAME = "UploadLetters";
-    private static final String INTERNATIONAL_FOLDER = "/international";
+    public static final String INTERNATIONAL_FOLDER = "/International";
 
     private final LetterRepository repo;
     private final FtpClient ftp;

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -171,7 +171,7 @@ class UploadLettersTaskTest {
             .sum();
 
         List<LogEvent> logEvents = uploadLettersTaskLogCaptor.getLogEvents();
-        assertTrue(logEvents.get(2).getMessage().contains("folder: some_folder/international"),ASSERTION_MESSAGE);
+        assertTrue(logEvents.get(2).getMessage().contains("folder: some_folder" + INTERNATIONAL_FOLDER),ASSERTION_MESSAGE);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -50,6 +50,7 @@ import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Created;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Skipped;
 import static uk.gov.hmcts.reform.sendletter.entity.LetterStatus.Uploaded;
 import static uk.gov.hmcts.reform.sendletter.launchdarkly.Flags.FACT_1593_INTERNATIONAL_POST_FLAG;
+import static uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask.INTERNATIONAL_FOLDER;
 import static uk.gov.hmcts.reform.sendletter.tasks.UploadLettersTask.SMOKE_TEST_LETTER_TYPE;
 
 @ExtendWith(MockitoExtension.class)
@@ -144,7 +145,7 @@ class UploadLettersTaskTest {
     @Test
     void should_handle_smoke_test_international_letters() {
         // given
-        given(serviceFolderMapping.getFolderFor(any())).willReturn(Optional.of("some_folder/international"));
+        given(serviceFolderMapping.getFolderFor(any())).willReturn(Optional.of("some_folder" + INTERNATIONAL_FOLDER));
 
         given(launchDarklyClient.isFeatureEnabled(FACT_1593_INTERNATIONAL_POST_FLAG)).willReturn(true);
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/tasks/UploadLettersTaskTest.java
@@ -171,7 +171,8 @@ class UploadLettersTaskTest {
             .sum();
 
         List<LogEvent> logEvents = uploadLettersTaskLogCaptor.getLogEvents();
-        assertTrue(logEvents.get(2).getMessage().contains("folder: some_folder" + INTERNATIONAL_FOLDER),ASSERTION_MESSAGE);
+        assertTrue(logEvents.get(2).getMessage()
+            .contains("folder: some_folder" + INTERNATIONAL_FOLDER),ASSERTION_MESSAGE);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1593


### Change description ###
changing international folder destination to match in filezilla to International. case is different.

Linked to 
https://github.com/hmcts/send-letter-service/pull/2466
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
