### PR TITLE
FACT-2138 added changes to add _IB to sscs isIbca prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,4 +237,3 @@ You can test the different environments of Send Letter Service by using [Send Le
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
-

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -394,7 +394,7 @@ public class LetterService {
             createdAt,
             id,
             false,
-            (JsonNode) letter.getAdditionalData()
+            letter.getAdditionalData()
         );
 
         return PgpEncryptionUtil.encryptFile(zipContent, zipFileName, pgpPublicKey);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/LetterService.java
@@ -393,7 +393,8 @@ public class LetterService {
             serviceName,
             createdAt,
             id,
-            false
+            false,
+            (JsonNode) letter.getAdditionalData()
         );
 
         return PgpEncryptionUtil.encryptFile(zipContent, zipFileName, pgpPublicKey);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
@@ -20,6 +20,7 @@ public final class FileNameHelper {
 
     public static final DateTimeFormatter dateTimeFormatter = ofPattern("ddMMyyyyHHmmss");
     private static final String SEPARATOR = "_";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Generates a PDF file name for a given letter.
@@ -70,7 +71,6 @@ public final class FileNameHelper {
      * @return The file name
      */
     public static String generateName(Letter letter) {
-        ObjectMapper objectMapper = new ObjectMapper();
         return generateName(
             letter.getType(),
             letter.getService(),

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
@@ -120,12 +120,10 @@ public final class FileNameHelper {
      *
      */
     public static String infectedBloodInfix(String service, Map<String, Object> additionalData) {
-        if ("sscs".equalsIgnoreCase(service)
-            && additionalData != null
-            && additionalData.containsKey("isIbca")) {
+        if ("sscs".equalsIgnoreCase(service) && additionalData != null && additionalData.containsKey("isIbca")) {
 
             Object isIbcaValue = additionalData.get("isIbca");
-            if (isIbcaValue instanceof Boolean && (Boolean) isIbcaValue) {
+            if ("true".equalsIgnoreCase(String.valueOf(isIbcaValue))) {
                 return SEPARATOR + "IB";
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/util/FileNameHelper.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.sendletter.services.util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.microsoft.applicationinsights.core.dependencies.apachecommons.io.FilenameUtils;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.exception.UnableToExtractIdFromFileNameException;
@@ -118,7 +116,7 @@ public final class FileNameHelper {
      * @param service The letter type
      * @param additionalData The additional data
      * @return "_IB" if the type is "sscs" and if isIbca in additionalInfo infected blood param is true,
-     * otherwise an empty string.
+     *      otherwise an empty string.
      *
      */
     public static String infectedBloodInfix(String service, Map<String, Object> additionalData) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/util/CsvWriter.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sendletter.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.slf4j.Logger;
@@ -209,7 +210,7 @@ public final class CsvWriter {
     private static void printStaleRecords(BasicLetterInfo letter, CSVPrinter printer, AtomicInteger count) {
         try {
             printer.printRecord(FileNameHelper.generateName(letter.getType(),
-                letter.getService(), letter.getCreatedAt(), letter.getId(), true),
+                letter.getService(), letter.getCreatedAt(), letter.getId(), true, null),
                     letter.getService(), letter.getCreatedAt(),
                     letter.getSentToPrintAt());
             count.incrementAndGet();
@@ -228,7 +229,7 @@ public final class CsvWriter {
     private static void printDelayRecords(BasicLetterInfo letter, CSVPrinter printer, AtomicInteger count) {
         try {
             printer.printRecord(FileNameHelper.generateName(letter.getType(),
-                letter.getService(), letter.getCreatedAt(), letter.getId(), true),
+                letter.getService(), letter.getCreatedAt(), letter.getId(), true, null),
                     letter.getService(), letter.getCreatedAt(),
                     letter.getSentToPrintAt(), letter.getPrintedAt());
             count.incrementAndGet();

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/util/CsvWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/util/CsvWriter.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sendletter.util;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.slf4j.Logger;

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FileNameHelperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sendletter.services.zip;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
@@ -164,9 +163,9 @@ class FileNameHelperTest {
 
     @Test
     void should_return_infected_blood_infix_when_type_is_sscs_and_isIbca_is_true() {
-        JsonNode additionalData = objectMapper.valueToTree(Map.of("isIbca", true));
+        Map<String, Object> additionalData = Map.of("isIbca", true);
 
-        String result = FileNameHelper.infectedBloodInfix(sscs, additionalData);
+        String result = FileNameHelper.infectedBloodInfix("sscs", additionalData);
 
         assertThat(result).isEqualTo("_IB");
     }
@@ -174,7 +173,7 @@ class FileNameHelperTest {
     @Test
     void should_return_empty_string_when_type_is_not_sscs() {
         String type = "notSscs";
-        JsonNode additionalData = objectMapper.valueToTree(Map.of("isIbca", true));
+        Map<String, Object> additionalData = Map.of("isIbca", true);
 
         String result = FileNameHelper.infectedBloodInfix(type, additionalData);
 
@@ -184,7 +183,7 @@ class FileNameHelperTest {
     @Test
     void should_return_empty_string_when_additional_data_is_null() {
         String type = "sscs";
-        JsonNode additionalData = null;
+        Map<String, Object> additionalData = null;
 
         String result = FileNameHelper.infectedBloodInfix(type, additionalData);
 
@@ -193,16 +192,15 @@ class FileNameHelperTest {
 
     @Test
     void should_return_empty_string_when_isIbca_is_missing_or_false() {
-        JsonNode missingFieldData = objectMapper.valueToTree(Map.of());
-        JsonNode falseFieldData = objectMapper.valueToTree(Map.of("isIbca", false));
+        Map<String, Object> missingFieldData = Map.of();
+        Map<String, Object> falseFieldData = Map.of("isIbca", false);
 
-        String resultMissing = FileNameHelper.infectedBloodInfix(sscs, missingFieldData);
-        String resultFalse = FileNameHelper.infectedBloodInfix(sscs, falseFieldData);
+        String resultMissing = FileNameHelper.infectedBloodInfix("sscs", missingFieldData);
+        String resultFalse = FileNameHelper.infectedBloodInfix("sscs", falseFieldData);
 
         assertThat(resultMissing).isEqualTo("");
         assertThat(resultFalse).isEqualTo("");
     }
-
 
     @Test
     void should_remove_underscores_from_service_name() {

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FileNameHelperTest.java
@@ -22,7 +22,7 @@ class FileNameHelperTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final String sscs = "sscs";
+    private static final String SSCS = "sscs";
 
     @Test
     void should_generate_file_name_in_expected_format() {
@@ -165,7 +165,7 @@ class FileNameHelperTest {
     void should_return_infected_blood_infix_when_type_is_sscs_and_isIbca_is_true() {
         Map<String, Object> additionalData = Map.of("isIbca", true);
 
-        String result = FileNameHelper.infectedBloodInfix("sscs", additionalData);
+        String result = FileNameHelper.infectedBloodInfix(SSCS, additionalData);
 
         assertThat(result).isEqualTo("_IB");
     }
@@ -182,10 +182,9 @@ class FileNameHelperTest {
 
     @Test
     void should_return_empty_string_when_additional_data_is_null() {
-        String type = "sscs";
         Map<String, Object> additionalData = null;
 
-        String result = FileNameHelper.infectedBloodInfix(type, additionalData);
+        String result = FileNameHelper.infectedBloodInfix(SSCS, additionalData);
 
         assertThat(result).isEqualTo("");
     }
@@ -195,8 +194,8 @@ class FileNameHelperTest {
         Map<String, Object> missingFieldData = Map.of();
         Map<String, Object> falseFieldData = Map.of("isIbca", false);
 
-        String resultMissing = FileNameHelper.infectedBloodInfix("sscs", missingFieldData);
-        String resultFalse = FileNameHelper.infectedBloodInfix("sscs", falseFieldData);
+        String resultMissing = FileNameHelper.infectedBloodInfix(SSCS, missingFieldData);
+        String resultFalse = FileNameHelper.infectedBloodInfix(SSCS, falseFieldData);
 
         assertThat(resultMissing).isEqualTo("");
         assertThat(resultFalse).isEqualTo("");

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/zip/FileNameHelperTest.java
@@ -162,8 +162,17 @@ class FileNameHelperTest {
     }
 
     @Test
-    void should_return_infected_blood_infix_when_type_is_sscs_and_isIbca_is_true() {
+    void should_return_infected_blood_infix_when_type_is_sscs_and_isIbca_is_true_as_boolean() {
         Map<String, Object> additionalData = Map.of("isIbca", true);
+
+        String result = FileNameHelper.infectedBloodInfix(SSCS, additionalData);
+
+        assertThat(result).isEqualTo("_IB");
+    }
+
+    @Test
+    void should_return_infected_blood_infix_when_type_is_sscs_and_isIbca_is_true_as_string() {
+        Map<String, Object> additionalData = Map.of("isIbca", "true");
 
         String result = FileNameHelper.infectedBloodInfix(SSCS, additionalData);
 


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-2138


### Change description ###
for sscs when they send isIbca:true in additionalData then add _IB to zip/pgp file name


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
