### PR TITLE
FACT-2740-cron-timeout-updates

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
@@ -7,7 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.sendletter.exception.FtpDownloadException;
+import uk.gov.hmcts.reform.sendletter.entity.Report;
+import uk.gov.hmcts.reform.sendletter.entity.ReportRepository;
 import uk.gov.hmcts.reform.sendletter.model.out.CheckPostedTaskResponse;
 import uk.gov.hmcts.reform.sendletter.model.out.PostedReportTaskResponse;
 import uk.gov.hmcts.reform.sendletter.services.CheckLettersPostedService;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,19 +44,12 @@ class TaskControllerTest {
     @MockitoBean
     private CheckLettersPostedService checkLettersPostedService;
 
-    @Test
-    void processReportsShouldReturn503WhenFtpDownloadExceptionOccurs() throws Exception {
-        when(markLettersPostedService.processReports())
-            .thenThrow(new FtpDownloadException("Download Failed!"));
-
-        mockMvc.perform(get("/tasks/process-reports")
-                .header("Authorization", AUTH_HEADER))
-            .andExpect(status().isServiceUnavailable());
-    }
+    @MockitoBean
+    private ReportRepository reportRepository;
 
     @Test
     void processReportsShouldReturn204WhenEmpty() throws Exception {
-        when(markLettersPostedService.processReports()).thenReturn(Collections.emptyList());
+        when(reportRepository.findByProcessedAtAfter(any())).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/tasks/process-reports")
                 .header("Authorization", AUTH_HEADER))
@@ -64,9 +59,14 @@ class TaskControllerTest {
     @Test
     void processReportsShouldReturn200WithList() throws Exception {
         final LocalDate reportDate = LocalDate.now();
-        PostedReportTaskResponse item = new PostedReportTaskResponse("CODE1", reportDate, false);
-        item.setMarkedPostedCount(100);
-        when(markLettersPostedService.processReports()).thenReturn(List.of(item));
+        Report report = Report.builder()
+            .reportCode("CODE1")
+            .reportDate(reportDate)
+            .isInternational(false)
+            .printedLettersCount(100)
+            .build();
+
+        when(reportRepository.findByProcessedAtAfter(any())).thenReturn(List.of(report));
 
         String responseBodyStr = mockMvc.perform(get("/tasks/process-reports")
                 .header("Authorization", AUTH_HEADER))
@@ -77,7 +77,7 @@ class TaskControllerTest {
             responseBodyStr, new TypeReference<List<PostedReportTaskResponse>>() {});
 
         assertThat(response).isNotNull().hasSize(1);
-        assertThat(response.getFirst()).isEqualTo(item);
+        assertThat(response.getFirst()).isEqualTo(PostedReportTaskResponse.fromReport(report));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TaskController.class)
@@ -48,16 +49,23 @@ class TaskControllerTest {
     private ReportRepository reportRepository;
 
     @Test
-    void processReportsShouldReturn204WhenEmpty() throws Exception {
+    void processedReportsShouldReturn204WhenEmpty() throws Exception {
         when(reportRepository.findByProcessedAtAfter(any())).thenReturn(Collections.emptyList());
 
-        mockMvc.perform(get("/tasks/process-reports")
+        mockMvc.perform(get("/tasks/processed-reports")
                 .header("Authorization", AUTH_HEADER))
             .andExpect(status().isNoContent());
     }
 
     @Test
-    void processReportsShouldReturn200WithList() throws Exception {
+    void processReportsShouldReturn204() throws Exception {
+        mockMvc.perform(post("/tasks/process-reports")
+                .header("Authorization", AUTH_HEADER))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void processedReportsShouldReturn200WithList() throws Exception {
         final LocalDate reportDate = LocalDate.now();
         Report report = Report.builder()
             .reportCode("CODE1")
@@ -68,7 +76,7 @@ class TaskControllerTest {
 
         when(reportRepository.findByProcessedAtAfter(any())).thenReturn(List.of(report));
 
-        String responseBodyStr = mockMvc.perform(get("/tasks/process-reports")
+        String responseBodyStr = mockMvc.perform(get("/tasks/processed-reports")
                 .header("Authorization", AUTH_HEADER))
             .andExpect(status().isOk())
             .andReturn().getResponse().getContentAsString();
@@ -96,7 +104,7 @@ class TaskControllerTest {
 
     @Test
     void shouldReturn401WhenMissingApiKey() throws Exception {
-        mockMvc.perform(get("/tasks/process-reports"))
+        mockMvc.perform(get("/tasks/processed-reports"))
             .andExpect(status().isUnauthorized());
     }
 
@@ -104,7 +112,7 @@ class TaskControllerTest {
     void shouldReturn401WhenInvalidApiKey() throws Exception {
         // Would normally expect a 403, but historically the api has been
         // written to throw an unauthorised in this situation.
-        mockMvc.perform(get("/tasks/process-reports")
+        mockMvc.perform(get("/tasks/processed-reports")
                 .header("Authorization", INVALID_AUTH_HEADER))
             .andExpect(status().isUnauthorized());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/e2e/BaseTest.java
@@ -28,7 +28,6 @@ import uk.gov.hmcts.reform.sendletter.entity.LetterRepository;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.helper.FakeFtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
-import uk.gov.hmcts.reform.sendletter.model.out.PostedReportTaskResponse;
 import uk.gov.hmcts.reform.sendletter.services.LocalSftpServer;
 import uk.gov.hmcts.reform.sendletter.services.MarkLettersPostedService;
 import uk.gov.hmcts.reform.sendletter.services.encryption.PgpDecryptionHelper;
@@ -136,13 +135,7 @@ class BaseTest {
             createCsvReport(server);
 
             // Run the process-report task manually as it is no longer a scheduled task
-            await()
-                .forever()
-                .untilAsserted(() -> {
-                    List<PostedReportTaskResponse> mpResp = markLettersPostedService.processReports();
-                    assertThat(mpResp).isNotNull().isNotEmpty().hasSize(1);
-                    assertThat(mpResp.getFirst()).isNotNull().extracting("processingFailed").isEqualTo(false);
-                });
+            markLettersPostedService.processReports();
 
             // The report should be processed and the letter marked posted.
             await()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/ReportRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sendletter/entity/ReportRepositoryTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.sendletter.entity;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class ReportRepositoryTest {
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @BeforeEach
+    void setUp() {
+        reportRepository.deleteAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        reportRepository.deleteAll();
+    }
+
+    @Test
+    void should_save_and_find_report_by_code_date_and_international_false() {
+        Report report = Report.builder()
+            .reportName("Test Report")
+            .reportCode("CODE1")
+            .reportDate(LocalDate.now())
+            .printedLettersCount(10)
+            .isInternational(false)
+            .status(ReportStatus.SUCCESS)
+            .build();
+        reportRepository.save(report);
+
+        Optional<Report> found = reportRepository.findFirstByReportCodeAndReportDateAndIsInternational(
+            "CODE1", LocalDate.now(), false);
+        assertThat(found).isPresent();
+        assertThat(found.get().getReportName()).isEqualTo("Test Report");
+        assertThat(found.get().getPrintedLettersCount()).isEqualTo(10);
+        assertThat(found.get().isInternational()).isFalse();
+        assertThat(found.get().getStatus()).isEqualTo(ReportStatus.SUCCESS);
+    }
+
+    @Test
+    void should_return_empty_when_no_matching_report() {
+        Optional<Report> found = reportRepository.findFirstByReportCodeAndReportDateAndIsInternational(
+            "NON_EXISTENT", LocalDate.now(), false);
+        assertThat(found).isNotPresent();
+    }
+
+    @Test
+    void should_find_reports_processed_after_given_timestamp() {
+        LocalDateTime beforeSave = LocalDateTime.now().minusMinutes(1);
+        Report report1 = Report.builder()
+            .reportName("Report 1")
+            .reportCode("CODE1")
+            .reportDate(LocalDate.now())
+            .printedLettersCount(5)
+            .isInternational(false)
+            .status(ReportStatus.SUCCESS)
+            .build();
+        Report report2 = Report.builder()
+            .reportName("Report 2")
+            .reportCode("CODE2")
+            .reportDate(LocalDate.now())
+            .printedLettersCount(7)
+            .isInternational(true)
+            .status(ReportStatus.FAIL)
+            .build();
+        Report report3 = Report.builder()
+            .reportName("Report 3")
+            .reportCode("CODE3")
+            .reportDate(LocalDate.now())
+            .printedLettersCount(9)
+            .isInternational(false)
+            .status(ReportStatus.SUCCESS)
+            .build();
+        reportRepository.save(report1);
+        reportRepository.save(report2);
+        reportRepository.save(report3);
+        // All reports should have processedAt after beforeSave
+        List<Report> found = reportRepository.findByProcessedAtAfter(beforeSave);
+        assertThat(found).hasSize(3);
+        assertThat(found).extracting(Report::getReportName)
+            .containsExactlyInAnyOrder("Report 1", "Report 2", "Report 3");
+    }
+
+    @Test
+    void should_return_empty_list_when_no_reports_processed_after_given_timestamp() {
+        Report report = Report.builder()
+            .reportName("Report 1")
+            .reportCode("CODE1")
+            .reportDate(LocalDate.now())
+            .printedLettersCount(5)
+            .isInternational(false)
+            .status(ReportStatus.SUCCESS)
+            .build();
+        reportRepository.save(report);
+        // Use a timestamp after the save, so no reports should match
+        LocalDateTime afterSave = LocalDateTime.now().plusMinutes(1);
+        List<Report> found = reportRepository.findByProcessedAtAfter(afterSave);
+        assertThat(found).isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/TaskController.java
@@ -75,12 +75,21 @@ public class TaskController {
     public ResponseEntity<List<PostedReportTaskResponse>> retrieveReports(
         @RequestHeader(value = AUTHORIZATION, required = false) String authHeader,
         @RequestParam(name = "after", required = false) LocalDateTime afterDate) {
+
         validateAuthorization(authHeader);
+
         LocalDateTime after = afterDate != null
             ? afterDate
             : LocalDateTime.now().truncatedTo(ChronoUnit.DAYS);
-        return ResponseEntity.ok(reportRepository.findByProcessedAtAfter(after).stream()
-                .map(PostedReportTaskResponse::fromReport).toList());
+
+        List<PostedReportTaskResponse> reports = reportRepository.findByProcessedAtAfter(after).stream()
+            .map(PostedReportTaskResponse::fromReport).toList();
+
+        if (reports.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(reports);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/TaskController.java
@@ -71,7 +71,7 @@ public class TaskController {
      * @param authHeader Auth header from the request containing the API key
      * @return a {@link List} of {@link PostedReportTaskResponse} records
      */
-    @GetMapping("/process-reports")
+    @GetMapping("/processed-reports")
     public ResponseEntity<List<PostedReportTaskResponse>> retrieveReports(
         @RequestHeader(value = AUTHORIZATION, required = false) String authHeader,
         @RequestParam(name = "after", required = false) LocalDateTime afterDate) {

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/TaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/controllers/TaskController.java
@@ -5,16 +5,23 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.sendletter.entity.ReportRepository;
 import uk.gov.hmcts.reform.sendletter.exception.InvalidApiKeyException;
 import uk.gov.hmcts.reform.sendletter.model.out.CheckPostedTaskResponse;
 import uk.gov.hmcts.reform.sendletter.model.out.PostedReportTaskResponse;
 import uk.gov.hmcts.reform.sendletter.services.CheckLettersPostedService;
 import uk.gov.hmcts.reform.sendletter.services.MarkLettersPostedService;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
@@ -26,34 +33,56 @@ public class TaskController {
     final String apiKey;
     final MarkLettersPostedService markLettersPostedService;
     final CheckLettersPostedService checkLettersPostedService;
+    final ReportRepository reportRepository;
+
+    static final Executor executor =  Executors.newSingleThreadExecutor();
 
     public TaskController(@Value("${actions.api-key}") String apiKey,
                           MarkLettersPostedService markLettersPostedService,
-                          CheckLettersPostedService checkLettersPostedService) {
+                          CheckLettersPostedService checkLettersPostedService,
+                          ReportRepository reportRepository) {
         this.apiKey = apiKey;
         this.markLettersPostedService = markLettersPostedService;
         this.checkLettersPostedService = checkLettersPostedService;
+        this.reportRepository = reportRepository;
     }
 
     /**
      * Kicks off report processing in the Mark Letters Posted Service.
      *
      * @param authHeader Auth header from the request containing the API key
+     * @return a no-content response if the task was successfully scheduled
+     */
+    @PostMapping("/process-reports")
+    public ResponseEntity<Void> processReports(
+        @RequestHeader(value = AUTHORIZATION, required = false) String authHeader) {
+        validateAuthorization(authHeader);
+        // this may throw a RejectedExecutionException, which will be picked up
+        // by the ResponseExceptionHandler and dealt with appropriately
+        executor.execute(markLettersPostedService::processReports);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Retrieves the set of reports that have been processed by the Mark Letters Posted Service,
+     * optionally filtered by a date. If the after date is not specified, the start of the current
+     * day will be used.
+     *
+     * @param authHeader Auth header from the request containing the API key
      * @return a {@link List} of {@link PostedReportTaskResponse} records
      */
     @GetMapping("/process-reports")
-    public ResponseEntity<List<PostedReportTaskResponse>> processReports(
-        @RequestHeader(value = AUTHORIZATION, required = false) String authHeader) {
+    public ResponseEntity<List<PostedReportTaskResponse>> retrieveReports(
+        @RequestHeader(value = AUTHORIZATION, required = false) String authHeader,
+        @RequestParam(name = "after", required = false) LocalDateTime afterDate) {
         validateAuthorization(authHeader);
-
-        List<PostedReportTaskResponse> response = markLettersPostedService.processReports();
-
-        if (response.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
-
-        return ResponseEntity.ok(response);
+        LocalDateTime after = afterDate != null
+            ? afterDate
+            : LocalDateTime.now().truncatedTo(ChronoUnit.DAYS);
+        return ResponseEntity.ok(reportRepository.findByProcessedAtAfter(after).stream()
+                .map(PostedReportTaskResponse::fromReport).toList());
     }
+
 
     /**
      * Kicks of the letter check in the Check Letters Posted Service.

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Report.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Report.java
@@ -55,4 +55,10 @@ public class Report {
     LocalDateTime processedAt;
 
     private boolean isInternational;
+
+    @NotNull
+    private ReportStatus status;
+
+    private String errorMessage;
 }
+

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Report.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/Report.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -57,6 +59,7 @@ public class Report {
     private boolean isInternational;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
     private ReportStatus status;
 
     private String errorMessage;

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/ReportRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/ReportRepository.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.sendletter.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,6 +22,14 @@ public interface ReportRepository extends JpaRepository<Report, UUID> {
      */
     Optional<Report> findFirstByReportCodeAndReportDateAndIsInternational(
         String reportCode, LocalDate reportDate, boolean isInternational);
+
+    /**
+     * Retrieves all reports processed after a specific timestamp.
+     *
+     * @param timestamp the date and time after which reports were processed
+     * @return a list of {@link Report} entities processed after the given timestamp
+     */
+    List<Report> findByProcessedAtAfter(LocalDateTime timestamp);
 }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/entity/ReportStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/entity/ReportStatus.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.reform.sendletter.entity;
+
+public enum ReportStatus {
+    SUCCESS,
+    FAIL,
+}

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/PostedReportTaskResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/model/out/PostedReportTaskResponse.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.sendletter.model.out;
 
 import lombok.Data;
+import uk.gov.hmcts.reform.sendletter.entity.Report;
+import uk.gov.hmcts.reform.sendletter.entity.ReportStatus;
 
 import java.time.LocalDate;
 
@@ -19,5 +21,25 @@ public class PostedReportTaskResponse {
     public void markAsFailed(String errorMessage) {
         this.processingFailed = true;
         this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Maps a {@link Report} to a {@link PostedReportTaskResponse}, extracting the relevant
+     * information and status.
+     *
+     * @param report the {@link Report}
+     * @return the {@link PostedReportTaskResponse} containing the report details and status
+     */
+    public static PostedReportTaskResponse fromReport(Report report) {
+        PostedReportTaskResponse response = new PostedReportTaskResponse(
+            report.getReportCode(),
+            report.getReportDate(),
+            report.isInternational()
+        );
+        response.setMarkedPostedCount(report.getPrintedLettersCount());
+        if (report.getStatus() == ReportStatus.FAIL) {
+            response.markAsFailed(report.getErrorMessage());
+        }
+        return response;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/CheckLettersPostedService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/CheckLettersPostedService.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.sendletter.entity.BasicLetterInfo;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.entity.ReportRepository;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
+import uk.gov.hmcts.reform.sendletter.exception.LetterSaveException;
 import uk.gov.hmcts.reform.sendletter.model.out.CheckPostedTaskResponse;
 
 import java.time.LocalDateTime;
@@ -63,6 +64,11 @@ public class CheckLettersPostedService {
                 }
             } catch (LetterNotFoundException e) {
                 log.warn("Letter not found for id {} during posted check", letter.getId());
+            } catch (LetterSaveException e) {
+                // this can happen when trying to retrieve the status of a letter that has
+                // it's ID as an entry in the exception table. In this case we just move on
+                // to the next letter and raise an info logs.
+                log.info("Exception record found for id {} during posted check. Skipping", letter.getId());
             }
         }
         log.info("Completed '{}' task", TASK_NAME);

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/MarkLettersPostedService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/MarkLettersPostedService.java
@@ -112,6 +112,7 @@ public class MarkLettersPostedService {
                         // but an error report will be added to indicate that a report couldn't be married
                         // up to a specific service.
                         currentReport.set(Report.builder()
+                            .reportName(parsedReport.path)
                             .reportCode("UNKNOWN")
                             .reportDate(parsedReport.reportDate)
                             .isInternational(false)
@@ -125,6 +126,7 @@ public class MarkLettersPostedService {
                         // initialise a report now so that we can ensure a report in the case of an
                         // exceptional failure during the markAsPosted iteration below.
                         currentReport.set(Report.builder()
+                            .reportName(parsedReport.path)
                             .reportCode(reportInfo.reportCode)
                             .reportDate(reportInfo.reportDate)
                             .isInternational(reportInfo.isInternational)

--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/MarkLettersPostedService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/MarkLettersPostedService.java
@@ -8,12 +8,11 @@ import uk.gov.hmcts.reform.sendletter.config.ReportsServiceConfig;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.entity.Report;
 import uk.gov.hmcts.reform.sendletter.entity.ReportRepository;
-import uk.gov.hmcts.reform.sendletter.exception.FtpDownloadException;
+import uk.gov.hmcts.reform.sendletter.entity.ReportStatus;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.LetterPrintStatus;
 import uk.gov.hmcts.reform.sendletter.model.ParsedReport;
-import uk.gov.hmcts.reform.sendletter.model.out.PostedReportTaskResponse;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 import uk.gov.hmcts.reform.sendletter.services.ftp.IFtpAvailabilityChecker;
 
@@ -24,9 +23,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -87,14 +83,13 @@ public class MarkLettersPostedService {
     /**
      * Fetches reports from SFTP and sets status as Posted in the database.
      */
-    public List<PostedReportTaskResponse> processReports() {
+    public void processReports() {
         if (!ftpAvailabilityChecker.isFtpAvailable(LocalTime.now(ZoneId.of(EUROPE_LONDON)))) {
             logger.info("Not processing '{}' task due to FTP downtime window", TASK_NAME);
-            return Collections.emptyList();
+            return;
         }
         logger.info("Started '{}' task", TASK_NAME);
-        final AtomicReference<PostedReportTaskResponse> currentResponse = new AtomicReference<>();
-        final List<PostedReportTaskResponse> responseList = new ArrayList<>();
+        final AtomicReference<Report> currentReport = new AtomicReference<>();
         try {
             ftpClient
                 .downloadReports()
@@ -114,81 +109,61 @@ public class MarkLettersPostedService {
                         // to determine a report code from their assigned service.
                         //
                         // When this happens, processing is allowed to move on to the next parsed report,
-                        // but an error response will be added to indicate that a report couldn't be married
+                        // but an error report will be added to indicate that a report couldn't be married
                         // up to a specific service.
-                        currentResponse.set(new PostedReportTaskResponse(
-                            "UNKNOWN",
-                            parsedReport.reportDate,
-                            false)
+                        currentReport.set(Report.builder()
+                            .reportCode("UNKNOWN")
+                            .reportDate(parsedReport.reportDate)
+                            .isInternational(false)
+                            .status(ReportStatus.FAIL)
+                            .errorMessage(String.format("Service not found for report with name '%s'",
+                                parsedReport.path))
+                            .build()
                         );
-                        currentResponse.get().markAsFailed(
-                            String.format("Service not found for report with name '%s'", parsedReport.path));
                     } else {
 
-                        // initialise a response now so that we can ensure a response in the case of an
+                        // initialise a report now so that we can ensure a report in the case of an
                         // exceptional failure during the markAsPosted iteration below.
-                        currentResponse.set(new PostedReportTaskResponse(
-                            reportInfo.reportCode,
-                            reportInfo.reportDate,
-                            reportInfo.isInternational)
+                        currentReport.set(Report.builder()
+                            .reportCode(reportInfo.reportCode)
+                            .reportDate(reportInfo.reportDate)
+                            .isInternational(reportInfo.isInternational)
+                            .build()
                         );
 
                         long count = parsedReport.statuses.stream()
                             .filter(status -> markAsPosted(status, parsedReport.path))
                             .count();
 
-                        currentResponse.get().setMarkedPostedCount(count);
+                        currentReport.get().setPrintedLettersCount(count);
 
                         if (parsedReport.allRowsParsed) {
                             logger.info("Report {} successfully parsed, deleting", parsedReport.path);
                             ftpClient.deleteReport(parsedReport.path);
-                            // now that we've processed the file, we can save a report.
-                            reportRepository.save(Report.builder()
-                                .reportName(parsedReport.path)
-                                .reportCode(reportInfo.reportCode)
-                                .reportDate(reportInfo.reportDate)
-                                .printedLettersCount(count)
-                                .isInternational(reportInfo.isInternational)
-                                .build()
-                            );
+                            currentReport.get().setStatus(ReportStatus.SUCCESS);
                         } else {
                             logger.warn("Report {} contained invalid rows, file not removed.", parsedReport.path);
-                            currentResponse.get().markAsFailed("Report "
+                            currentReport.get().setStatus(ReportStatus.FAIL);
+                            currentReport.get().setErrorMessage("Report "
                                 + parsedReport.path + " contained invalid rows");
                         }
                     }
-                    responseList.add(currentResponse.getAndSet(null));
+                    // save whatever report we made above.
+                    reportRepository.save(currentReport.getAndSet(null));
                 });
 
             logger.info("Completed '{}' task", TASK_NAME);
         } catch (Exception e) {
             logger.error("An error occurred when downloading reports from SFTP server", e);
-            // If we opened a response before the exception was thrown, we need to commit
-            // that response to the list and mark it up as an error.
-            Optional.ofNullable(currentResponse.getAndSet(null)).ifPresentOrElse(ptr -> {
-                ptr.markAsFailed(
-                    "An error occurred when processing downloaded reports from the SFTP server: " + e.getMessage());
-                responseList.add(ptr);
-            }, () -> {
-                // otherwise, make a choice about adding a general error or just throwing a 503
-                if (responseList.isEmpty()) {
-                    // if we have an empty response list at this point, we should
-                    // throw a formal 503
-                    throw new FtpDownloadException("An error occurred when downloading reports from SFTP server", e);
-                } else {
-                    // if the response list already has some errors in it then we need to add
-                    // another one with an UNKNOWN report code that details the error
-                    PostedReportTaskResponse errorReport =
-                        new PostedReportTaskResponse("UNKNOWN", LocalDate.now(), false);
-                    errorReport.setMarkedPostedCount(0);
-                    errorReport.markAsFailed(
-                        "An error occurred when processing reports from SFTP server: " + e.getMessage());
-                    responseList.add(errorReport);
-                }
+            // If we opened a report before the exception was thrown, we need to commit
+            // that report to the list and mark it up as an error.
+            Optional.ofNullable(currentReport.getAndSet(null)).ifPresent(ptr -> {
+                ptr.setStatus(ReportStatus.FAIL);
+                ptr.setErrorMessage("An error occurred when processing downloaded reports from the SFTP server: "
+                    + e.getMessage());
+                reportRepository.save(ptr);
             });
-
         }
-        return responseList;
     }
 
     /**

--- a/src/main/resources/db/migration/V034__Add_report_status_columns.sql
+++ b/src/main/resources/db/migration/V034__Add_report_status_columns.sql
@@ -1,0 +1,11 @@
+-- Add status and error_message columns to the reports table
+ALTER TABLE reports
+  ADD COLUMN status VARCHAR(10),
+  ADD COLUMN error_message VARCHAR;
+
+-- Set the status to 'SUCCESS' for all existing reports
+UPDATE reports SET status = 'SUCCESS' WHERE status IS NULL;
+
+-- Prevent NULL values in the status column going forward
+ALTER TABLE reports
+  ALTER COLUMN status SET NOT NULL;

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.sendletter.services.MarkLettersPostedService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,8 +56,6 @@ class TaskControllerTest {
 
     @Test
     void processReportsShouldReturn204() {
-        when(markLettersPostedService.processReports()).thenReturn(Collections.emptyList());
-
         ResponseEntity<Void> response =
             controller.processReports(AUTH_HEADER);
 

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/controllers/TaskControllerTest.java
@@ -7,6 +7,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.sendletter.entity.Report;
+import uk.gov.hmcts.reform.sendletter.entity.ReportRepository;
+import uk.gov.hmcts.reform.sendletter.entity.ReportStatus;
 import uk.gov.hmcts.reform.sendletter.exception.InvalidApiKeyException;
 import uk.gov.hmcts.reform.sendletter.model.out.CheckPostedTaskResponse;
 import uk.gov.hmcts.reform.sendletter.model.out.PostedReportTaskResponse;
@@ -14,11 +17,14 @@ import uk.gov.hmcts.reform.sendletter.services.CheckLettersPostedService;
 import uk.gov.hmcts.reform.sendletter.services.MarkLettersPostedService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class TaskControllerTest {
@@ -32,20 +38,28 @@ class TaskControllerTest {
     @Mock
     private CheckLettersPostedService checkLettersPostedService;
 
+    @Mock
+    private ReportRepository reportRepository;
+
     @InjectMocks
     private TaskController controller;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        controller = new TaskController(API_KEY, markLettersPostedService, checkLettersPostedService);
+        controller = new TaskController(
+            API_KEY,
+            markLettersPostedService,
+            checkLettersPostedService,
+            reportRepository
+        );
     }
 
     @Test
-    void processReportsShouldReturn204WhenListIsEmpty() {
+    void processReportsShouldReturn204() {
         when(markLettersPostedService.processReports()).thenReturn(Collections.emptyList());
 
-        ResponseEntity<List<PostedReportTaskResponse>> response =
+        ResponseEntity<Void> response =
             controller.processReports(AUTH_HEADER);
 
         assertThat(response).isNotNull();
@@ -54,18 +68,33 @@ class TaskControllerTest {
     }
 
     @Test
-    void processReportShouldReturn200WithList() {
-        PostedReportTaskResponse item = new PostedReportTaskResponse("file1", LocalDate.now(), false);
-        when(markLettersPostedService.processReports())
-            .thenReturn(List.of(item));
+    void retrieveReportsShouldReturn200WithList() {
+        Report report = Report.builder()
+            .reportName("Test Report")
+            .reportCode("CODE1")
+            .reportDate(LocalDate.now())
+            .printedLettersCount(10)
+            .isInternational(false)
+            .status(ReportStatus.SUCCESS)
+            .build();
+
+        when(reportRepository.findByProcessedAtAfter(any()))
+            .thenReturn(List.of(report));
 
         ResponseEntity<List<PostedReportTaskResponse>> response =
-            controller.processReports(AUTH_HEADER);
+            controller.retrieveReports(AUTH_HEADER, LocalDateTime.now().truncatedTo(ChronoUnit.DAYS));
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode().value()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.hasBody()).isTrue();
-        assertThat(response.getBody()).containsExactly(item);
+
+        List<PostedReportTaskResponse> body = response.getBody();
+        assertThat(body).hasSize(1);
+        assertThat(body.getFirst().getReportCode()).isEqualTo(report.getReportCode());
+        assertThat(body.getFirst().getReportDate()).isEqualTo(report.getReportDate());
+        assertThat(body.getFirst().isInternational()).isEqualTo(report.isInternational());
+        assertThat(body.getFirst().getMarkedPostedCount()).isEqualTo(report.getPrintedLettersCount());
+        assertThat(body.getFirst().isProcessingFailed()).isFalse();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sendletter/services/MarkLettersPostedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sendletter/services/MarkLettersPostedTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.sendletter.SampleData;
@@ -12,11 +13,11 @@ import uk.gov.hmcts.reform.sendletter.config.ReportsServiceConfig;
 import uk.gov.hmcts.reform.sendletter.entity.Letter;
 import uk.gov.hmcts.reform.sendletter.entity.LetterStatus;
 import uk.gov.hmcts.reform.sendletter.entity.ReportRepository;
+import uk.gov.hmcts.reform.sendletter.entity.ReportStatus;
 import uk.gov.hmcts.reform.sendletter.exception.LetterNotFoundException;
 import uk.gov.hmcts.reform.sendletter.logging.AppInsights;
 import uk.gov.hmcts.reform.sendletter.model.ParsedReport;
 import uk.gov.hmcts.reform.sendletter.model.Report;
-import uk.gov.hmcts.reform.sendletter.model.out.PostedReportTaskResponse;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpAvailabilityChecker;
 import uk.gov.hmcts.reform.sendletter.services.ftp.FtpClient;
 
@@ -24,7 +25,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -174,18 +174,20 @@ class MarkLettersPostedTest {
         given(reportsServiceConfig.getReportCodes()).willReturn(Set.of("CODE1", "CODE2"));
 
         // when
-        List<PostedReportTaskResponse> processedReports = task.processReports();
+        task.processReports();
 
         // then
         verify(ftpClient, never()).deleteReport(reportName);
-        assertThat(processedReports).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(processedReports.getFirst()).satisfies(p -> {
-            assertThat(p.isProcessingFailed()).isTrue();
-            assertThat(p.getMarkedPostedCount()).isZero();
-            assertThat(p.getErrorMessage()).isNotEmpty().contains(
-                String.format("Service not found for report with name '%s'",  reportName)
-            );
-        });
+        ArgumentCaptor<uk.gov.hmcts.reform.sendletter.entity.Report> reportCaptor =
+            ArgumentCaptor.forClass(uk.gov.hmcts.reform.sendletter.entity.Report.class);
+        verify(reportRepository, times(1)).save(reportCaptor.capture());
+        uk.gov.hmcts.reform.sendletter.entity.Report report = reportCaptor.getValue();
+        assertThat(report).isNotNull();
+        assertThat(report.getStatus()).isEqualTo(ReportStatus.FAIL);
+        assertThat(report.getPrintedLettersCount()).isZero();
+        assertThat(report.getErrorMessage()).isNotEmpty().contains(
+            String.format("Service not found for report with name '%s'",  reportName)
+        );
     }
 
     @Test
@@ -223,21 +225,22 @@ class MarkLettersPostedTest {
         given(dataAccessService.findLetterStatus(any())).willReturn(Optional.of(LetterStatus.Uploaded));
 
         // when
-        List<PostedReportTaskResponse> processedReports = task.processReports();
+        task.processReports();
 
         // then
         verify(dataAccessService, times(parsedReport.statuses.size()))
             .markLetterAsPosted(any(),any(LocalDateTime.class));
         verify(ftpClient).deleteReport(reportName);
-        verify(reportRepository).save(any());
-        assertThat(processedReports).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(processedReports.getFirst()).satisfies(p -> {
-            assertThat(p.isProcessingFailed()).isFalse();
-            // SampleData parsedReport has 2 letters in it
-            assertThat(p.getMarkedPostedCount()).isEqualTo(parsedReport.statuses.size());
-            assertThat(p.getErrorMessage()).isNull();
-            assertThat(p.getReportCode()).isEqualTo("CODE1");
-        });
+        ArgumentCaptor<uk.gov.hmcts.reform.sendletter.entity.Report> reportCaptor =
+            ArgumentCaptor.forClass(uk.gov.hmcts.reform.sendletter.entity.Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        uk.gov.hmcts.reform.sendletter.entity.Report report = reportCaptor.getValue();
+        assertThat(report).isNotNull();
+        assertThat(report.getStatus()).isEqualTo(ReportStatus.SUCCESS);
+        // SampleData parsedReport has 2 letters in it
+        assertThat(report.getPrintedLettersCount()).isEqualTo(parsedReport.statuses.size());
+        assertThat(report.getErrorMessage()).isNull();
+        assertThat(report.getReportCode()).isEqualTo("CODE1");
     }
 
     @Test
@@ -262,19 +265,20 @@ class MarkLettersPostedTest {
             .markLetterAsPosted(any(UUID.class),any(LocalDateTime.class));
 
         // when
-        List<PostedReportTaskResponse> processedReports = task.processReports();
+        task.processReports();
 
         // then
         verify(ftpClient, never()).deleteReport(reportName);
-        verify(reportRepository, never()).save(any());
-        assertThat(processedReports).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(processedReports.getFirst()).satisfies(p -> {
-            assertThat(p.isProcessingFailed()).isTrue();
-            assertThat(p.getMarkedPostedCount()).isZero();
-            assertThat(p.getErrorMessage()).isNotEmpty().contains(
-                "An error occurred when processing downloaded reports from the SFTP server: test exception message"
-            );
-        });
+        ArgumentCaptor<uk.gov.hmcts.reform.sendletter.entity.Report> reportCaptor =
+            ArgumentCaptor.forClass(uk.gov.hmcts.reform.sendletter.entity.Report.class);
+        verify(reportRepository, times(1)).save(reportCaptor.capture());
+        uk.gov.hmcts.reform.sendletter.entity.Report report = reportCaptor.getValue();
+        assertThat(report).isNotNull();
+        assertThat(report.getStatus()).isEqualTo(ReportStatus.FAIL);
+        assertThat(report.getPrintedLettersCount()).isZero();
+        assertThat(report.getErrorMessage()).isNotEmpty().contains(
+            "An error occurred when processing downloaded reports from the SFTP server: test exception message"
+        );
     }
 
     @Test
@@ -316,13 +320,16 @@ class MarkLettersPostedTest {
         given(dataAccessService.findLetterStatus(any())).willReturn(Optional.of(LetterStatus.Uploaded));
 
         // when
-        List<PostedReportTaskResponse> processedReports = task.processReports();
+        task.processReports();
 
         // then
         verify(ftpClient).deleteReport(reportName);
-        verify(reportRepository).save(any());
-        assertThat(processedReports).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(processedReports.getFirst().getReportCode()).isEqualTo("CODE1");
+        ArgumentCaptor<uk.gov.hmcts.reform.sendletter.entity.Report> reportCaptor =
+            ArgumentCaptor.forClass(uk.gov.hmcts.reform.sendletter.entity.Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        uk.gov.hmcts.reform.sendletter.entity.Report report = reportCaptor.getValue();
+        assertThat(report).isNotNull();
+        assertThat(report.getReportCode()).isEqualTo("CODE1");
     }
 
 
@@ -342,13 +349,16 @@ class MarkLettersPostedTest {
         given(reportsServiceConfig.getReportCodes()).willReturn(Set.of("CODE1", "CODE2"));
 
         // when
-        List<PostedReportTaskResponse> processedReports = task.processReports();
+        task.processReports();
 
         // then
         verify(ftpClient).deleteReport(reportName);
-        verify(reportRepository).save(any());
-        assertThat(processedReports).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(processedReports.getFirst().getReportDate()).isEqualTo(LocalDate.of(2026,1,13));
+        ArgumentCaptor<uk.gov.hmcts.reform.sendletter.entity.Report> reportCaptor =
+            ArgumentCaptor.forClass(uk.gov.hmcts.reform.sendletter.entity.Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        uk.gov.hmcts.reform.sendletter.entity.Report report = reportCaptor.getValue();
+        assertThat(report).isNotNull();
+        assertThat(report.getReportDate()).isEqualTo(LocalDate.of(2026,1,13));
     }
 
     @Test
@@ -367,13 +377,16 @@ class MarkLettersPostedTest {
         given(reportsServiceConfig.getReportCodes()).willReturn(Set.of("CODE1", "CODE2"));
 
         // when
-        List<PostedReportTaskResponse> processedReports = task.processReports();
+        task.processReports();
 
         // then
         verify(ftpClient).deleteReport(reportName);
-        verify(reportRepository).save(any());
-        assertThat(processedReports).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(processedReports.getFirst().getReportDate()).isEqualTo(parsedReport.reportDate);
+        ArgumentCaptor<uk.gov.hmcts.reform.sendletter.entity.Report> reportCaptor =
+            ArgumentCaptor.forClass(uk.gov.hmcts.reform.sendletter.entity.Report.class);
+        verify(reportRepository).save(reportCaptor.capture());
+        uk.gov.hmcts.reform.sendletter.entity.Report report = reportCaptor.getValue();
+        assertThat(report).isNotNull();
+        assertThat(report.getReportDate()).isEqualTo(parsedReport.reportDate);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[FACT-2740](https://tools.hmcts.net/jira/browse/FACT-2740)

### Change description ###

Updates to address timeout issues when running the report processing task.

task has been split into two separate endpoints:

- A `POST` endpoint to trigger the report download and posted status updates
  - always returns a 204. 
- A `GET` endpoint that can retrieve reports that have been added to the DB since a given timestamp
  - returns a 200/204 as applicable 

report processing now saves a report regardless of the outcome (previously it only saved reports on successful processing and subsequent deletion of the downloaded sftp report). Errors that used to be reported in the response list are now attached to the report row in the DB so that later retrieval can indicate any issues.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
