### PR TITLE
Grant new jenkins mi per environment on the KV

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -14,12 +14,18 @@ module "send-letter-key-vault" {
   tenant_id           = var.tenant_id
   object_id           = var.jenkins_AAD_objectId
   resource_group_name = azurerm_resource_group.rg.name
+  jenkins_object_id   = data.azurerm_user_assigned_identity.jenkins.principal_id
 
   # dcd_cc-dev group object ID
   product_group_object_id              = "38f9dea6-e861-4a50-9e73-21e64f563537"
   common_tags                          = var.common_tags
   create_managed_identity              = true
   additional_managed_identities_access = ["rpe-shared", "bulk-scan"]
+}
+
+data "azurerm_user_assigned_identity" "jenkins" {
+  name                = "jenkins-${var.env}-mi"
+  resource_group_name = "managed-identities-${var.env}-rg"
 }
 
 data "azurerm_key_vault_secret" "smtp_username" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-30508


### Change description ###

We (Platform Operations) are adding an additional Jenkins MIs that are per-environment.
This will ensure that pipeline for this repository does not break once we start enforcing access segmentation within Jenkins
Here is the epic for some context: https://tools.hmcts.net/jira/browse/DTSPO-29659
Essentially we want to make sure each pipeline only has the access to whatever is necessary and nothing more, this means going from generalised Managed Identity used for all jobs across environments to environment specific ones.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
