### PR TITLE
switch to equals() comparator and reorder for npe avoidance

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sendletter/services/ReportsService.java
@@ -97,8 +97,8 @@ public class ReportsService {
             endDate.plusDays(1).atStartOfDay())
             .stream()
             .filter(sl ->
-                sl.getCreatedAt().getDayOfWeek() != DayOfWeek.SATURDAY
-                && sl.getCreatedAt().getDayOfWeek() != DayOfWeek.SUNDAY)
+                !DayOfWeek.SATURDAY.equals(sl.getCreatedAt().getDayOfWeek())
+                && !DayOfWeek.SUNDAY.equals(sl.getCreatedAt().getDayOfWeek()))
             .toList();
 
         Set<String> presentReports =


### PR DESCRIPTION
### Change description ###

Fix a sonar equality intentionality issue that is preventing master branch from passing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
